### PR TITLE
Add server map browser toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
 
     /* Overlay (initial file chooser) */
     #overlayMsg {
-      position: fixed; left:220px; top:0; width:calc(100vw - 220px); height:100vh;
+      position: fixed; left:0; top:0; width:100vw; height:100vh;
       display: flex; align-items: center; justify-content: center;
       font-size: 2.5rem; color: #ccc; pointer-events: auto; z-index: 100;
       background: rgba(21,30,40,0.98); text-shadow: 0 2px 10px #000, 0 0 1px #fff;
@@ -189,7 +189,7 @@
   </div>
 
   <div id="threeContainer"></div>
-  <div id="fileList"></div>
+  <div id="fileList" class="hidden"></div>
   <div id="info"></div>
 
   <!-- Overlay -->
@@ -197,6 +197,7 @@
     <div style="text-align:center;">
       <div id="overlayText" style="font-size:42px;color:#ddd;letter-spacing:1px;margin-bottom:16px;">Please select map</div>
       <label for="wzLoader" id="overlayBrowseBtn" class="overlay-btn">Browse map…</label>
+      <button id="overlayServerBtn" class="overlay-btn" style="margin-left:10px;">Browse server maps</button>
       <input type="file" id="wzLoader" accept=".wz,.zip,.7z,.map,.gam,.json" style="position:absolute;left:-9999px;width:0.1px;height:0.1px;opacity:0;">
       <div style="margin-top:10px;font-size:14px;color:#aab;">Please wait, it can take some time…</div>
     </div>
@@ -220,6 +221,17 @@
       var input = document.getElementById('wzLoader');
       const fileListDiv = document.getElementById('fileList');
       const overlayEl = document.getElementById('overlayMsg');
+      const serverBtn = document.getElementById('overlayServerBtn');
+      if(serverBtn){
+        serverBtn.addEventListener('click', () => {
+          fileListDiv.classList.toggle('hidden');
+          if(fileListDiv.classList.contains('hidden')){
+            if(overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }
+          }else{
+            if(overlayEl){ overlayEl.style.left='220px'; overlayEl.style.width='calc(100vw - 220px)'; }
+          }
+        });
+      }
       if (btn && input){
         btn.addEventListener('click', function(ev){
           ev.preventDefault();
@@ -239,8 +251,6 @@
             div.textContent = file;
             div.addEventListener('click', () => {
               window.UI.hideOverlay();
-              fileListDiv.classList.add('hidden');
-              if (overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }
               fileListDiv.classList.add('hidden');
               if (overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }
               window.UI.showTopBar(true);
@@ -263,6 +273,8 @@
         window.UI.hideOverlay();
         window.UI.showTopBar(true);
         window.UI.setMapFilename(file.name);
+        fileListDiv.classList.add('hidden');
+        if (overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }
 
         // If your app exposes loadWzArchive, call it; else dispatch event
         try{
@@ -278,6 +290,8 @@
           window.UI.showTopBar(false);
           window.UI.setMapFilename('');
           input.value='';
+          fileListDiv.classList.add('hidden');
+          if (overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }
         }
       });
     });


### PR DESCRIPTION
## Summary
- Hide server map list by default and add "Browse server maps" button
- Toggle left map panel visibility from overlay and reset after map load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8404afdc8333b098c3d52a5ddf8f