### PR TITLE
Copy map URL instead of downloading

### DIFF
--- a/maps/index.html
+++ b/maps/index.html
@@ -1,53 +1,68 @@
-<h2>File List</h2>
-<ul id="fileList">
-  <li>Loading files...</li>
-</ul>
-
-<p style="font-size:0.9em;color:#90a4b8;">Click a map to copy its link and view it in the browser.</p>
-      files.forEach(file => {
-        const li = document.createElement('li');
-        const link = document.createElement('a');
-        link.href = file;
-        link.textContent = file;
-        link.target = "_blank";
-        link.addEventListener('click', (e) => {
-          e.preventDefault();
-          const url = link.href;
-          if (navigator.clipboard) {
-            navigator.clipboard.writeText(url).catch(err => console.error('Clipboard error:', err));
-          }
-          window.open('../index.html?url=' + encodeURIComponent(url), '_blank');
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Folder Explorer</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #151e28; color: #dde; margin: 0; padding: 20px; }
+    h1 { color: #4da3ff; }
+    a { color: #4da3ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 5px; }
+    .file-type { font-size: 0.9em; color: #90a4b8; margin-left: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Folder Explorer</h1>
+  <p>
+    <a href="index.php" target="_blank">Scan Folder (index.php)</a>
+  </p>
+  <p style="font-size:0.9em;color:#90a4b8;">Click a map to copy its link and view it in the browser.</p>
+  <h2>File List</h2>
+  <ul id="fileList">
+    <li>Loading files...</li>
+  </ul>
+  <script>
+    async function loadFileList() {
+      const fileListContainer = document.getElementById('fileList');
+      try {
+        const response = await fetch('filelist.txt');
+        if (!response.ok) throw new Error('filelist.txt not found!');
+        const text = await response.text();
+        const files = text.split(/\r?\n/).filter(f => f.trim() !== '');
+        fileListContainer.innerHTML = '';
+        files.forEach(file => {
+          const li = document.createElement('li');
+          const link = document.createElement('a');
+          link.href = file;
+          link.textContent = file;
+          link.addEventListener('click', (e) => {
+            e.preventDefault();
+            const url = link.href;
+            if (navigator.clipboard) {
+              navigator.clipboard.writeText(url).catch(err => console.error('Clipboard error:', err));
+            }
+            window.open('../index.html?url=' + encodeURIComponent(url), '_blank');
+          });
+          const ext = file.split('.').pop();
+          const span = document.createElement('span');
+          span.textContent = ext;
+          span.className = 'file-type';
+          li.appendChild(link);
+          li.appendChild(span);
+          fileListContainer.appendChild(li);
         });
-<style>
-  body { font-family: Arial, sans-serif; background: #151e28; color: #dde; margin: 0; padding: 20px; }
-  h1 { color: #4da3ff; }
-  a { color: #4da3ff; text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  ul { list-style: none; padding: 0; }
-  li { margin-bottom: 5px; }
-  .file-type { font-size: 0.9em; color: #90a4b8; margin-left: 8px; }
-</style>
-</head>
-<body>
-
-<h1>Folder Explorer</h1>
-
-<p>
-  <a href="index.php" target="_blank">Scan Folder (index.php)</a>
-</p>
-
-<h2>File List</h2>
-<ul id="fileList">
-  <li>Loading files...</li>
-</ul>
-
-<script>
-  async function loadFileList() {
-    const fileListContainer = document.getElementById('fileList');
-    try {
-      const response = await fetch('filelist.txt');
-      if (!response.ok) throw new Error('filelist.txt not found!');
-      const text = await response.text();
+      } catch (err) {
+        fileListContainer.innerHTML = '<li>Error loading file list.</li>';
+        console.error(err);
+      }
+    }
+    loadFileList();
+  </script>
+</body>
+</html>
+
       const files = text.split(/\r?\n/).filter(f => f.trim() !== '');
       fileListContainer.innerHTML = '';
       files.forEach(file => {


### PR DESCRIPTION
## Summary
- Replace maps index page with a simple file list that copies the map URL and opens it in the viewer instead of triggering a download

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adab2efd2c8333a783eb6dcde4e400