### PR TITLE
Prevent remote map downloads when opening by URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,10 @@
         urlFrame.addEventListener('load', () => {
           const src = urlFrame.src;
           if(/\.(wz|zip|map|json)(\?|#|$)/i.test(src)){
+            // prevent the browser from downloading the map
+            urlFrame.src = 'about:blank';
+            // copy the URL to clipboard if possible
+            try{ navigator.clipboard?.writeText(src); }catch(e){}
             urlPopup.style.display = 'none';
             fileListDiv.classList.add('hidden');
             if(overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }


### PR DESCRIPTION
## Summary
- Avoid browser download when selecting a remote map by clearing the iframe and copying the map URL to the clipboard
- Load the remote map directly in the viewer using the captured URL

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68add12d0a0c8333afbe39965ddab7b6