### PR TITLE
Prevent remote map downloads when opening by URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,14 +91,19 @@
       position: fixed; left:0; top:0; width:100vw; height:100vh;
       background:#000; z-index:200; display:none;
     }
-    #urlPopup iframe{
-      width:100%; height:100%; border:none;
-    }
-    #urlPopupClose{
-      position:absolute; top:8px; right:8px; z-index:201;
-      background:#2c7be5; color:#fff; border:none; border-radius:4px;
-      padding:6px 10px; cursor:pointer;
-    }
+      #urlPopup iframe{
+        width:100%; height:100%; border:none;
+      }
+      #urlPopupClose{
+        position:absolute; top:8px; right:8px; z-index:201;
+        background:#2c7be5; color:#fff; border:none; border-radius:4px;
+        padding:6px 10px; cursor:pointer;
+      }
+      #urlPopupLoad{
+        position:absolute; top:8px; left:8px; z-index:201;
+        background:#2c7be5; color:#fff; border:none; border-radius:4px;
+        padding:6px 10px; cursor:pointer;
+      }
 
   </style>
 </head>
@@ -224,6 +229,7 @@
   <!-- Remote URL popup -->
   <div id="urlPopup">
     <button id="urlPopupClose">Close</button>
+    <button id="urlPopupLoad">Open copied link</button>
     <iframe id="urlPopupFrame" src=""></iframe>
   </div>
 
@@ -250,6 +256,7 @@
       const urlPopup = document.getElementById('urlPopup');
       const urlFrame = document.getElementById('urlPopupFrame');
       const urlClose = document.getElementById('urlPopupClose');
+      const urlLoad = document.getElementById('urlPopupLoad');
       if(serverBtn){
         const fileListWidth = 360;
         serverBtn.addEventListener('click', () => {
@@ -275,9 +282,34 @@
             urlPopup.style.display = 'none';
           });
         }
+        if(urlLoad){
+          urlLoad.addEventListener('click', async () => {
+            let src = '';
+            try{ src = (await navigator.clipboard.readText() || '').trim(); }catch(e){ console.error('Clipboard read error:', e); }
+            if(/\.(wz|zip|map|json)(\?|#|$)/i.test(src)){
+              urlFrame.src = '';
+              urlPopup.style.display = 'none';
+              fileListDiv.classList.add('hidden');
+              if(overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }
+              window.UI.hideOverlay();
+              window.UI.showTopBar(true);
+              window.UI.setMapFilename(src.split('/').pop());
+              window.loadRemoteMap(src).catch(err => {
+                console.error('Map load error:', err);
+                window.UI.showOverlay();
+                window.UI.showTopBar(false);
+                window.UI.setMapFilename('');
+              });
+            }
+          });
+        }
         urlFrame.addEventListener('load', () => {
           const src = urlFrame.src;
           if(/\.(wz|zip|map|json)(\?|#|$)/i.test(src)){
+            // prevent the browser from downloading the map
+            urlFrame.src = 'about:blank';
+            // copy the URL to clipboard if possible
+            try{ navigator.clipboard?.writeText(src); }catch(e){}
             urlPopup.style.display = 'none';
             fileListDiv.classList.add('hidden');
             if(overlayEl){ overlayEl.style.left='0'; overlayEl.style.width='100vw'; }


### PR DESCRIPTION
## Summary
- Avoid browser download when selecting a remote map by clearing the iframe and copying the map URL to the clipboard
- Load the remote map directly in the viewer using the captured URL
- Allow manually opening a copied map link from the URL popup via the new **Open copied link** button

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68add12d0a0c8333afbe39965ddab7b6