### PR TITLE
Fix external map browser URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
         urlBtn.addEventListener('click', () => {
           urlPopup.style.display = 'block';
           // Load the external map browser so users can preview maps with a Load button
-          urlFrame.src = 'https://maps.wz1000.net/#/';
+          urlFrame.src = 'https://maps.wz2100.net/#/';
         });
           if(urlClose){
           urlClose.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Correct the remote map browser URL to use maps.wz2100.net

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2fb62114833388024009732dd0e3