### PR TITLE
docs: recommend proxying remote map requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,6 +217,7 @@
       <button id="overlayUrlBtn" class="overlay-btn" style="margin-left:10px;">Open map URL</button>
       <input type="file" id="wzLoader" accept=".wz,.zip,.7z,.map,.gam,.json" style="position:absolute;left:-9999px;width:0.1px;height:0.1px;opacity:0;">
       <div style="margin-top:10px;font-size:14px;color:#aab;">Please wait, it can take some time…</div>
+      <div style="margin-top:6px;font-size:14px;color:#aab;">If a remote map fails to load, proxy the request.</div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- advise using a proxy when remote map URLs fail to load due to CORS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af759c962c8333bf43633572ae5729