### PR TITLE
Increase brush size limit to 255 with slider control

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,8 @@
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
         <label for="brushSizeInput" style="margin:0;">Brush Size:</label>
-        <input type="number" id="brushSizeInput" value="1" min="1" max="10" step="1" style="width:60px;">
+        <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
+        <input type="range" id="brushSizeSlider" min="1" max="255" value="1" style="flex:1;">
       </div>
       <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
       <div style="display:block; margin-top:6px; margin-bottom:4px;">
@@ -160,7 +161,8 @@
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
         <label for="heightBrushSizeInput" style="margin:0;">Brush Size:</label>
-        <input type="number" id="heightBrushSizeInput" value="1" min="1" max="10" step="1" style="width:60px;">
+        <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
+        <input type="range" id="heightBrushSizeSlider" min="1" max="255" value="1" style="flex:1;">
       </div>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -155,7 +155,7 @@ const initDom = () => {
   const brushSlider = document.getElementById('brushSizeSlider');
   const setBrush = (v) => {
     const n = parseInt(v, 10);
-    brushSize = isNaN(n) || n < 1 ? 1 : n;
+    brushSize = isNaN(n) ? 1 : Math.min(Math.max(n, 1), 255);
     if (brushInput) brushInput.value = brushSize;
     if (brushSlider) brushSlider.value = String(brushSize);
     if (lastMouseEvent) updateHighlight(lastMouseEvent);


### PR DESCRIPTION
## Summary
- Allow tile and height brush sizes up to 255
- Add range sliders to adjust brush size alongside numeric inputs
- Clamp brush size to valid range in game logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af83defdb08333896501d4445eeb98