### PR TITLE
Sync height brush controls and fix slider overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,13 +82,17 @@
     .overlay-btn:hover{ filter:brightness(1.1); }
   
     /* Hide panel while overlay is shown */
-    body.overlay-open #editPanel {
-      display:none;
-    }
+      body.overlay-open #editPanel {
+        display:none;
+      }
 
-  </style>
-</head>
-<body class="overlay-open">
+      input[type="range"] {
+        min-width: 0;
+      }
+
+    </style>
+  </head>
+  <body class="overlay-open">
 <select id="structureSelect" title="Structures"></select>
   <div id="uiBar" class="hidden">
     <span id="mapFilename"></span>

--- a/js/game.js
+++ b/js/game.js
@@ -151,15 +151,22 @@ const initDom = () => {
   });
   updateSelectedInfo();
   setActiveTab(activeTab);
-    const brushInput = document.getElementById('brushSizeInput');
+
+  const brushInput = document.getElementById('brushSizeInput');
   const brushSlider = document.getElementById('brushSizeSlider');
+  const heightBrushInput = document.getElementById('heightBrushSizeInput');
+  const heightBrushSlider = document.getElementById('heightBrushSizeSlider');
+
   const setBrush = (v) => {
     const n = parseInt(v, 10);
     brushSize = isNaN(n) ? 1 : Math.min(Math.max(n, 1), 255);
     if (brushInput) brushInput.value = brushSize;
     if (brushSlider) brushSlider.value = String(brushSize);
+    if (heightBrushInput) heightBrushInput.value = brushSize;
+    if (heightBrushSlider) heightBrushSlider.value = String(brushSize);
     if (lastMouseEvent) updateHighlight(lastMouseEvent);
   };
+
   if (brushInput) {
     brushSize = parseInt(brushInput.value, 10) || 1;
     brushInput.addEventListener('input', () => setBrush(brushInput.value));
@@ -169,19 +176,19 @@ const initDom = () => {
     brushSlider.value = String(brushSize);
     brushSlider.addEventListener('input', () => setBrush(brushSlider.value));
     brushSlider.addEventListener('change', () => setBrush(brushSlider.value));
-  }const heightBrushInput = document.getElementById('heightBrushSizeInput');
-const heightBrushSlider = document.getElementById('heightBrushSizeSlider');
-if (heightBrushInput) {
-  heightBrushInput.value = brushSize;
-  const syncHeight = (v) => setBrush(v);
-  heightBrushInput.addEventListener('input', () => syncHeight(heightBrushInput.value));
-  heightBrushInput.addEventListener('change', () => syncHeight(heightBrushInput.value));
-}
-if (heightBrushSlider) {
-  heightBrushSlider.value = String(brushSize);
-  heightBrushSlider.addEventListener('input', () => setBrush(heightBrushSlider.value));
-  heightBrushSlider.addEventListener('change', () => setBrush(heightBrushSlider.value));
-}const typeSelect = document.getElementById('tileTypeSelect');
+  }
+  if (heightBrushInput) {
+    heightBrushInput.value = brushSize;
+    heightBrushInput.addEventListener('input', () => setBrush(heightBrushInput.value));
+    heightBrushInput.addEventListener('change', () => setBrush(heightBrushInput.value));
+  }
+  if (heightBrushSlider) {
+    heightBrushSlider.value = String(brushSize);
+    heightBrushSlider.addEventListener('input', () => setBrush(heightBrushSlider.value));
+    heightBrushSlider.addEventListener('change', () => setBrush(heightBrushSlider.value));
+  }
+
+  const typeSelect = document.getElementById('tileTypeSelect');
   if (typeSelect) {
     typeSelect.addEventListener('change', () => {
       const val = parseInt(typeSelect.value, 10);


### PR DESCRIPTION
## Summary
- Ensure all brush size controls stay in sync, including height panel sliders.
- Constrain range slider width so it fits within the editor panel.

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68affe0b86608333890aef530675c470