### PR TITLE
Add brush toggle and update height tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,11 @@
       background: #283445; color: #dde; border: 1px solid #435066;
       padding: 2px 6px; cursor: pointer; font-size: 0.9rem;
     }
+    .action-btn {
+      background: #283445; color: #dde; border: 1px solid #435066;
+      padding: 2px 8px; cursor: pointer; font-size: 0.9rem;
+    }
+    .action-btn.active { background: #435066; }
     .toggle-label { color: #dde; user-select:none; font-size:1rem; display:flex; align-items:center; gap:4px; cursor:pointer; }
     .toggle-label input[type="checkbox"] { width:18px; height:18px; accent-color:#88f; }
 
@@ -164,13 +169,14 @@
         <button type="button" class="height-preset" data-val="255">255</button>
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
-        <label for="heightBrushSizeInput" style="margin:0; white-space:nowrap;">Brush size:</label>
+        <label for="heightBrushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
         <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
         <input type="range" id="heightBrushSizeSlider" min="1" max="255" value="1" style="flex:1;">
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
-        <button type="button" id="heightSelectBtn">Select on map</button>
-        <button type="button" id="heightApplyBtn">Apply</button>
+        <button type="button" id="heightBrushBtn" class="action-btn">Use Brush</button>
+        <button type="button" id="heightSelectBtn" class="action-btn">Draw on map</button>
+        <button type="button" id="heightApplyBtn" class="action-btn">Apply</button>
       </div>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -122,6 +122,7 @@ let highlightMesh = null;
 let previewGroup = null;
 let lastMouseEvent = null;
 let heightSelectionMode = false;
+let heightBrushMode = false;
 let heightSelectStart = null;
 let heightSelectEnd = null;
 const raycaster = new THREE.Raycaster();
@@ -193,11 +194,19 @@ const initDom = () => {
 
   const heightSelectBtn = document.getElementById('heightSelectBtn');
   const heightApplyBtn = document.getElementById('heightApplyBtn');
+  const heightBrushBtn = document.getElementById('heightBrushBtn');
 
   if (heightSelectBtn) {
     heightSelectBtn.addEventListener('click', () => {
       heightSelectionMode = !heightSelectionMode;
       heightSelectBtn.classList.toggle('active', heightSelectionMode);
+      if (heightBrushBtn) {
+        heightBrushBtn.disabled = heightSelectionMode;
+        if (heightSelectionMode) {
+          heightBrushMode = false;
+          heightBrushBtn.classList.remove('active');
+        }
+      }
       if (heightBrushInput) heightBrushInput.disabled = heightSelectionMode;
       if (heightBrushSlider) heightBrushSlider.disabled = heightSelectionMode;
       if (!heightSelectionMode) {
@@ -206,6 +215,27 @@ const initDom = () => {
         if (highlightMesh && scene) {
           scene.remove(highlightMesh);
           highlightMesh = null;
+        }
+      }
+      if (lastMouseEvent) updateHighlight(lastMouseEvent);
+    });
+  }
+
+  if (heightBrushBtn) {
+    heightBrushBtn.addEventListener('click', () => {
+      heightBrushMode = !heightBrushMode;
+      heightBrushBtn.classList.toggle('active', heightBrushMode);
+      if (heightSelectBtn) {
+        heightSelectBtn.disabled = heightBrushMode;
+        if (heightBrushMode) {
+          heightSelectionMode = false;
+          heightSelectBtn.classList.remove('active');
+          heightSelectStart = null;
+          heightSelectEnd = null;
+          if (highlightMesh && scene) {
+            scene.remove(highlightMesh);
+            highlightMesh = null;
+          }
         }
       }
       if (lastMouseEvent) updateHighlight(lastMouseEvent);
@@ -409,7 +439,7 @@ function handleEditClick(event) {
       }
     }
     if (__needsRedrawTex) drawMap3D();
-  } else if (activeTab === 'height') {
+  } else if (activeTab === 'height' && heightBrushMode) {
     let __needsRedrawHeight = false;
     let newHeight = selectedHeight;
     if (event.shiftKey) {
@@ -485,6 +515,13 @@ function __old_updateHighlight(event) {
       });
       scene.remove(previewGroup);
       previewGroup = null;
+    }
+    return;
+  }
+  if (activeTab === 'height' && !heightBrushMode) {
+    if (highlightMesh) {
+      scene.remove(highlightMesh);
+      highlightMesh = null;
     }
     return;
   }


### PR DESCRIPTION
## Summary
- Style action buttons and add a new `Use Brush` toggle
- Rename height selection button to `Draw on map` and shorten brush label to `Size`
- Only paint or highlight heights when brush mode is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b006ed90c483339b995313192b5573