### PR TITLE
Move brush button and enable direct mode switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,12 +169,12 @@
         <button type="button" class="height-preset" data-val="255">255</button>
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
+        <button type="button" id="heightBrushBtn" class="action-btn">Use Brush</button>
         <label for="heightBrushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
         <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
         <input type="range" id="heightBrushSizeSlider" min="1" max="255" value="1" style="flex:1;">
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
-        <button type="button" id="heightBrushBtn" class="action-btn">Use Brush</button>
         <button type="button" id="heightSelectBtn" class="action-btn">Draw on map</button>
         <button type="button" id="heightApplyBtn" class="action-btn">Apply</button>
       </div>

--- a/js/game.js
+++ b/js/game.js
@@ -198,24 +198,24 @@ const initDom = () => {
 
   if (heightSelectBtn) {
     heightSelectBtn.addEventListener('click', () => {
-      heightSelectionMode = !heightSelectionMode;
-      heightSelectBtn.classList.toggle('active', heightSelectionMode);
-      if (heightBrushBtn) {
-        heightBrushBtn.disabled = heightSelectionMode;
-        if (heightSelectionMode) {
-          heightBrushMode = false;
-          heightBrushBtn.classList.remove('active');
-        }
-      }
-      if (heightBrushInput) heightBrushInput.disabled = heightSelectionMode;
-      if (heightBrushSlider) heightBrushSlider.disabled = heightSelectionMode;
-      if (!heightSelectionMode) {
+      if (heightSelectionMode) {
+        heightSelectionMode = false;
+        heightSelectBtn.classList.remove('active');
+        if (heightBrushInput) heightBrushInput.disabled = false;
+        if (heightBrushSlider) heightBrushSlider.disabled = false;
         heightSelectStart = null;
         heightSelectEnd = null;
         if (highlightMesh && scene) {
           scene.remove(highlightMesh);
           highlightMesh = null;
         }
+      } else {
+        heightSelectionMode = true;
+        heightSelectBtn.classList.add('active');
+        heightBrushMode = false;
+        if (heightBrushBtn) heightBrushBtn.classList.remove('active');
+        if (heightBrushInput) heightBrushInput.disabled = true;
+        if (heightBrushSlider) heightBrushSlider.disabled = true;
       }
       if (lastMouseEvent) updateHighlight(lastMouseEvent);
     });
@@ -223,20 +223,22 @@ const initDom = () => {
 
   if (heightBrushBtn) {
     heightBrushBtn.addEventListener('click', () => {
-      heightBrushMode = !heightBrushMode;
-      heightBrushBtn.classList.toggle('active', heightBrushMode);
-      if (heightSelectBtn) {
-        heightSelectBtn.disabled = heightBrushMode;
-        if (heightBrushMode) {
-          heightSelectionMode = false;
-          heightSelectBtn.classList.remove('active');
-          heightSelectStart = null;
-          heightSelectEnd = null;
-          if (highlightMesh && scene) {
-            scene.remove(highlightMesh);
-            highlightMesh = null;
-          }
+      if (heightBrushMode) {
+        heightBrushMode = false;
+        heightBrushBtn.classList.remove('active');
+      } else {
+        heightBrushMode = true;
+        heightBrushBtn.classList.add('active');
+        heightSelectionMode = false;
+        if (heightSelectBtn) heightSelectBtn.classList.remove('active');
+        heightSelectStart = null;
+        heightSelectEnd = null;
+        if (highlightMesh && scene) {
+          scene.remove(highlightMesh);
+          highlightMesh = null;
         }
+        if (heightBrushInput) heightBrushInput.disabled = false;
+        if (heightBrushSlider) heightBrushSlider.disabled = false;
       }
       if (lastMouseEvent) updateHighlight(lastMouseEvent);
     });


### PR DESCRIPTION
## Summary
- Move "Use Brush" before size controls for a clearer layout
- Switch directly between brush and selection modes without manual deselection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b009bde1f4833386d47227cb4034b8