### PR TITLE
Add brush and selection tools to tile editing tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,9 +131,14 @@
         <span>Selected Tile: <span id="selectedTileIdDisplay">0</span></span>
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
-        <label for="brushSizeInput" style="margin:0;">Brush Size:</label>
+        <button type="button" id="tileBrushBtn" class="action-btn">Use Brush</button>
+        <label for="brushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
         <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
         <input type="range" id="brushSizeSlider" min="1" max="255" value="1" style="flex:1;">
+      </div>
+      <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
+        <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
+        <button type="button" id="tileApplyBtn" class="action-btn">Apply</button>
       </div>
       <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
       <div style="display:block; margin-top:6px; margin-bottom:4px;">


### PR DESCRIPTION
## Summary
- add brush toggle and selection controls to tiles tab
- support rectangular tile selection and apply
- sync tile editing modes with existing height tools

## Testing
- `node --check js/game.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b017ad82b08333b2faa2445d364d7b