### PR TITLE
Align tab content to the left in editor panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
     #editPanel {
       position:absolute; left:0; top:0; width:100vw; height:280px;
       background: rgba(24,32,48,0.95); padding:6px; z-index:12;
-      display:flex; align-items:flex-start; gap:10px;
-      overflow-x:auto; overflow-y:hidden;
+      display:flex; flex-direction:column; align-items:flex-start; gap:10px;
+      overflow-y:auto; overflow-x:hidden;
     }
     #editPanel .panel {
       width:280px; flex-shrink:0; height:100%; overflow-y:auto;


### PR DESCRIPTION
## Summary
- Stack editor panel elements vertically so tab content anchors to the left

## Testing
- `cd js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b01e28e458833384ff962fc579f1e2