### PR TITLE
Add pop-out menu window

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
 
   <!-- Top editor panel -->
   <div id="editPanel">
-    <div id="tabBar" style="display:flex; flex-wrap:wrap; gap:6px; margin-bottom:4px; overflow-x:auto;">
+    <div id="tabBar" style="display:none; flex-wrap:wrap; gap:6px; margin-bottom:4px; overflow-x:auto;">
       <button class="tab-btn" data-tab="view">View</button>
       <button class="tab-btn" data-tab="textures">Tiles</button>
       <button class="tab-btn" data-tab="height">Height</button>
@@ -350,6 +350,11 @@
         }
       });
     });
+</script>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    window.menuWindow = window.open('menu.html', 'wzmenu', 'width=' + window.screen.availWidth + ',height=60');
+  });
 </script>
 </body>
 </html>

--- a/js/game.js
+++ b/js/game.js
@@ -115,6 +115,7 @@ function populateStructureSelect() {
   selectedStructureIndex = -1;
 }
 let activeTab = 'view';
+window.activeTab = activeTab;
 let selectedTileId = 0;
 let selectedRotation = 0;
 let brushSize = 1;
@@ -926,6 +927,10 @@ function handleMouseMove(event) {
 }
 function setActiveTab(tab) {
   activeTab = tab;
+  window.activeTab = activeTab;
+  if (window.menuWindow && !window.menuWindow.closed) {
+    window.menuWindow.postMessage({ type: 'activeTab', tab: activeTab }, '*');
+  }
   document.querySelectorAll('.tab-btn').forEach(btn => {
     const isActive = btn.getAttribute('data-tab') === tab;
     btn.classList.toggle('active', isActive);
@@ -958,6 +963,14 @@ function setActiveTab(tab) {
     updateStructurePreview();
   }
 }
+window.setActiveTab = setActiveTab;
+window.addEventListener('message', (e) => {
+  if (e.data && e.data.type === 'requestActiveTab') {
+    if (window.menuWindow && !window.menuWindow.closed) {
+      window.menuWindow.postMessage({ type: 'activeTab', tab: activeTab }, '*');
+    }
+  }
+});
 function updateSelectedInfo() {
   const span = document.getElementById('selectedTileIdDisplay');
   if (span) {

--- a/menu.html
+++ b/menu.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Menu</title>
+  <style>
+    :root{
+      --bg:#151e28; --fg:#dde; --muted:#90a4b8; --bar:#151e28; --border:#283445; --accent:#4da3ff;
+    }
+    html, body{
+      margin:0; padding:0; background:var(--bar); color:var(--fg);
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    }
+    #menuBar{
+      display:flex; align-items:center; gap:6px; padding:4px 8px;
+      border-bottom:1px solid var(--border);
+      width:100%; box-sizing:border-box;
+    }
+    .tab-btn{
+      background:#283445; color:#dde; border:1px solid #435066;
+      padding:2px 8px; cursor:pointer; font-size:0.9rem;
+    }
+    .tab-btn.active{ background:#6CF527; color:#000; }
+  </style>
+</head>
+<body>
+  <div id="menuBar">
+    <button class="tab-btn" data-tab="view">View</button>
+    <button class="tab-btn" data-tab="textures">Tiles</button>
+    <button class="tab-btn" data-tab="height">Height</button>
+    <button class="tab-btn" data-tab="size">Resize</button>
+    <button class="tab-btn" data-tab="objects">Structures</button>
+  </div>
+  <script>
+    function activate(tab){
+      document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.getAttribute('data-tab') === tab);
+      });
+    }
+    window.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const tab = btn.getAttribute('data-tab');
+          if(window.opener && !window.opener.closed && window.opener.setActiveTab){
+            window.opener.setActiveTab(tab);
+          }
+          activate(tab);
+        });
+      });
+      if(window.opener){
+        window.opener.postMessage({type:'requestActiveTab'}, '*');
+      }
+    });
+    window.addEventListener('message', e => {
+      if(e.data && e.data.type === 'activeTab'){
+        activate(e.data.tab);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Hide in-page tab bar and open menu in a separate pop-out window.
- Implement standalone horizontal menu bar (menu.html) that controls main window tabs.
- Expose tab switching API and cross-window messaging in game.js.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02de4f48c8333af7d1fc05534814c