### PR TITLE
Embed menu in main index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <style>
     :root{
       --bg:#151e28; --fg:#dde; --muted:#90a4b8; --bar:#151e28; --border:#283445; --accent:#4da3ff;
+      --menu-height:40px;
     }
     html, body {
       height: 100%; margin: 0; padding: 0;
@@ -20,21 +21,26 @@
     }
     /* 3D container */
     #threeContainer {
-      position: absolute; left: 300px; top: 0; width: calc(100vw - 300px); height: 100vh;
+      position: absolute; left: 300px; top: var(--menu-height); width: calc(100vw - 300px); height: calc(100vh - var(--menu-height));
       background: var(--bg); z-index: 1;
     }
     body.overlay-open #threeContainer { left: 0; width: 100vw; }
     /* Top bar (kept but minimal; can be toggled by the game) */
     #uiBar {
-      position: absolute; left: 300px; top: 0; width: calc(100vw - 300px); z-index: 10;
+      position: absolute; left: 300px; top: var(--menu-height); width: calc(100vw - 300px); z-index: 10;
       padding: 4px 8px; background: var(--bar); border-bottom: 1px solid var(--border);
       display: flex; align-items: center; gap: 10px;
     }
     body.overlay-open #uiBar { left: 0; width: 100vw; }
     #uiBar.hidden { display:none; }
     #mapFilename { color:#8cf; }
+    #menuBar {
+      position: fixed; top:0; left:0; width:100%; height:var(--menu-height);
+      display:flex; align-items:center; gap:6px; padding:4px 8px;
+      background: var(--bar); border-bottom:1px solid var(--border); z-index:80; box-sizing:border-box;
+    }
     #fileList {
-      position: fixed; left:0; top:0; width:360px; height:100vh;
+      position: fixed; left:0; top:var(--menu-height); width:360px; height:calc(100vh - var(--menu-height));
       background: rgba(24,32,48,0.95);
       padding:8px; overflow-y:auto;
       z-index:60;
@@ -54,7 +60,7 @@
 
     /* Top editor panel */
     #editPanel {
-      position:absolute; left:0; top:0; width:300px; height:100vh;
+      position:absolute; left:0; top:var(--menu-height); width:300px; height:calc(100vh - var(--menu-height));
       background: rgba(24,32,48,0.95); padding:6px; z-index:12;
       display:flex; flex-direction:column; align-items:flex-start; gap:10px;
       overflow-x:hidden;
@@ -105,20 +111,19 @@
     </style>
   </head>
   <body class="overlay-open">
+  <div id="menuBar">
+    <button class="tab-btn" data-tab="view">View</button>
+    <button class="tab-btn" data-tab="textures">Tiles</button>
+    <button class="tab-btn" data-tab="height">Height</button>
+    <button class="tab-btn" data-tab="size">Resize</button>
+    <button class="tab-btn" data-tab="objects">Structures</button>
+  </div>
   <div id="uiBar" class="hidden">
     <span id="mapFilename"></span>
   </div>
 
   <!-- Top editor panel -->
   <div id="editPanel">
-    <div id="tabBar" style="display:none; flex-wrap:wrap; gap:6px; margin-bottom:4px; overflow-x:auto;">
-      <button class="tab-btn" data-tab="view">View</button>
-      <button class="tab-btn" data-tab="textures">Tiles</button>
-      <button class="tab-btn" data-tab="height">Height</button>
-      <button class="tab-btn" data-tab="size">Resize</button>
-      <button class="tab-btn" data-tab="objects">Structures</button>
-    </div>
-
     <div id="showOptions" style="display:flex; gap:8px; margin-bottom:2px;">
       <label class="toggle-label"><input type="checkbox" id="showHeight"> Show Heights</label>
       <label class="toggle-label"><input type="checkbox" id="showPanelIds" checked> Show IDs</label>
@@ -353,7 +358,6 @@
 </script>
 <script>
   window.addEventListener('DOMContentLoaded', () => {
-    window.menuWindow = window.open('menu.html', 'wzmenu', 'width=' + window.screen.availWidth + ',height=60');
   });
 </script>
 </body>

--- a/js/game.js
+++ b/js/game.js
@@ -928,9 +928,6 @@ function handleMouseMove(event) {
 function setActiveTab(tab) {
   activeTab = tab;
   window.activeTab = activeTab;
-  if (window.menuWindow && !window.menuWindow.closed) {
-    window.menuWindow.postMessage({ type: 'activeTab', tab: activeTab }, '*');
-  }
   document.querySelectorAll('.tab-btn').forEach(btn => {
     const isActive = btn.getAttribute('data-tab') === tab;
     btn.classList.toggle('active', isActive);
@@ -964,13 +961,6 @@ function setActiveTab(tab) {
   }
 }
 window.setActiveTab = setActiveTab;
-window.addEventListener('message', (e) => {
-  if (e.data && e.data.type === 'requestActiveTab') {
-    if (window.menuWindow && !window.menuWindow.closed) {
-      window.menuWindow.postMessage({ type: 'activeTab', tab: activeTab }, '*');
-    }
-  }
-});
 function updateSelectedInfo() {
   const span = document.getElementById('selectedTileIdDisplay');
   if (span) {


### PR DESCRIPTION
## Summary
- Replace popup menu with inline menu bar fixed to top of index.html
- Adjust layout to account for new menu bar and remove cross-window messaging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b03181d87083338e725add6dae2dac