### PR TITLE
Allow map rotation when no tools active in Tiles tab

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1476,7 +1476,7 @@ function drawMap3D() {
       resetCameraTarget(mapW, mapH, threeContainer);
     });
     threeContainer.addEventListener('mousedown', e => {
-      if (activeTab === 'textures') return;
+      if (activeTab === 'textures' && (tileBrushMode || tileSelectionMode)) return;
       isDragging = true;
       lastX = e.clientX;
       lastY = e.clientY;


### PR DESCRIPTION
## Summary
- Permit camera rotation in the Tiles tab when no editing tools are active

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b03b9c195483338e435ac07f9e2852