### PR TITLE
Enable arrow keys for camera movement

### DIFF
--- a/js/camera.js
+++ b/js/camera.js
@@ -25,7 +25,11 @@ export function resetCameraTarget(mapW, mapH, container) {
 export function setupKeyboard(resetCallback) {
   window.addEventListener('keydown', e => {
     cameraState.keys[e.key.toLowerCase()] = true;
+    if (e.key.startsWith('Arrow')) e.preventDefault();
     if (e.key.toLowerCase() === 'r') resetCallback();
   });
-  window.addEventListener('keyup', e => { cameraState.keys[e.key.toLowerCase()] = false; });
+  window.addEventListener('keyup', e => {
+    cameraState.keys[e.key.toLowerCase()] = false;
+    if (e.key.startsWith('Arrow')) e.preventDefault();
+  });
 }

--- a/js/game.js
+++ b/js/game.js
@@ -1631,6 +1631,10 @@ function updateCulling() {
     if (cameraState.keys['s']) moveZ += cameraState.camMoveSpeed * cameraState.zoom;
     if (cameraState.keys['a']) moveX -= cameraState.camMoveSpeed * cameraState.zoom;
     if (cameraState.keys['d']) moveX += cameraState.camMoveSpeed * cameraState.zoom;
+    if (cameraState.keys['arrowup']) moveZ -= cameraState.camMoveSpeed * cameraState.zoom;
+    if (cameraState.keys['arrowdown']) moveZ += cameraState.camMoveSpeed * cameraState.zoom;
+    if (cameraState.keys['arrowleft']) moveX -= cameraState.camMoveSpeed * cameraState.zoom;
+    if (cameraState.keys['arrowright']) moveX += cameraState.camMoveSpeed * cameraState.zoom;
     if (moveX || moveZ) {
       const angle = cameraState.rotationY;
       const fx = Math.sin(angle);


### PR DESCRIPTION
## Summary
- handle arrow key presses to prevent default page scrolling
- move camera with arrow keys alongside WASD

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03f2528cc8333b7651223634fe1d2