### PR TITLE
Reorder tile editor controls for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,6 @@
   <div id="editPanel">
     <div id="showOptions" style="display:flex; gap:8px; margin-bottom:2px;">
       <label class="toggle-label"><input type="checkbox" id="showHeight"> Show Heights</label>
-      <label class="toggle-label"><input type="checkbox" id="showPanelIds" checked> Show IDs</label>
-      <label class="toggle-label"><input type="checkbox" id="showTileId">Show IDs in map</label>
     </div>
 
     <!-- VIEW TAB -->
@@ -150,10 +148,9 @@
         <label for="tilesetSelect" style="margin:0;">Tileset:</label>
         <select id="tilesetSelect" style="flex:1;"></select>
       </div>
-      <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
-        <button id="rotateLeft" class="rotate-btn">⟲</button>
-        <button id="rotateRight" class="rotate-btn">⟳</button>
-        <span>Selected Tile: <span id="selectedTileIdDisplay">0</span></span>
+      <div id="tileIdOptions" style="display:flex; gap:8px; margin-bottom:4px;">
+        <label class="toggle-label"><input type="checkbox" id="showPanelIds" checked> Show IDs</label>
+        <label class="toggle-label"><input type="checkbox" id="showTileId">Show IDs in map</label>
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
         <button type="button" id="tileBrushBtn" class="action-btn">Use Brush</button>
@@ -164,6 +161,11 @@
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
         <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
         <button type="button" id="tileApplyBtn" class="action-btn">Apply</button>
+      </div>
+      <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
+        <button id="rotateLeft" class="rotate-btn">⟲</button>
+        <button id="rotateRight" class="rotate-btn">⟳</button>
+        <span>Selected Tile: <span id="selectedTileIdDisplay">0</span></span>
       </div>
       <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
       <div style="display:block; margin-top:6px; margin-bottom:4px;">

--- a/js/game.js
+++ b/js/game.js
@@ -936,25 +936,13 @@ function setActiveTab(tab) {
   panels.forEach(p => { p.style.display = 'none'; });
   const panel = document.getElementById(tab + 'Panel');
   if (panel) panel.style.display = 'block';
-  const tileToggle = document.getElementById('showTileId');
-  if (tileToggle && tileToggle.parentElement) {
-    tileToggle.parentElement.style.display = (tab === 'textures') ? 'flex' : 'none';
-  }
-  const panelIdsToggle = document.getElementById('showPanelIds');
-  if (panelIdsToggle && panelIdsToggle.parentElement) {
-    panelIdsToggle.parentElement.style.display = (tab === 'textures') ? 'flex' : 'none';
-  }
   const heightToggle = document.getElementById('showHeight');
   if (heightToggle && heightToggle.parentElement) {
     heightToggle.parentElement.style.display = (tab === 'height') ? 'flex' : 'none';
   }
   const showOptions = document.getElementById('showOptions');
   if (showOptions) {
-    if (tab === 'textures' || tab === 'height') {
-      showOptions.style.display = 'flex';
-    } else {
-      showOptions.style.display = 'none';
-    }
+    showOptions.style.display = (tab === 'height') ? 'flex' : 'none';
   }
   if (tab === 'objects') {
     updateStructurePreview();


### PR DESCRIPTION
## Summary
- Move Show IDs options below the Tileset selector
- Place rotation buttons and selected tile info after Draw on map
- Adjust tab handling for new control locations

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b0464c27888333be7daebd257b4e91