### PR TITLE
Move tile type selector next to Type label

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,8 @@
         <button id="rotateLeft" class="rotate-btn">⟲</button>
         <button id="rotateRight" class="rotate-btn">⟳</button>
         <span>Selected Tile: <span id="selectedTileIdDisplay">0</span></span>
+        <span id="selectedTileTypeLabel" style="margin-left:10px; color:#cfe8ff;">Type:</span>
+        <select id="tileTypeSelect"></select>
       </div>
       <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
       <div class="tile-options-box">
@@ -180,10 +182,6 @@
         <div style="display:flex; gap:8px;">
           <label class="toggle-label"><input type="checkbox" id="displayTileTypes"> Tile type</label>
           <label class="toggle-label"><input type="checkbox" id="showTileTypesOnMap"> Tile type in map</label>
-        </div>
-        <div style="display:flex; align-items:center; gap:6px; margin-top:6px;">
-          <label for="tileTypeSelect" style="margin:0;">Change tile type</label>
-          <select id="tileTypeSelect" style="flex:1;"></select>
         </div>
       </div>
     </div>

--- a/js/game.js
+++ b/js/game.js
@@ -960,26 +960,9 @@ function updateSelectedInfo() {
     typeSelect.value = typeVal;
     selectedTileType = typeVal;
   }
-  // Inline selected tile type next to the ID
-  try {
-    const span = document.getElementById('selectedTileIdDisplay');
-    const parent = span ? span.parentElement : null;
-    let typeLabel = document.getElementById('selectedTileTypeLabel');
-    if (!typeLabel && parent) {
-      typeLabel = document.createElement('span');
-      typeLabel.id = 'selectedTileTypeLabel';
-      typeLabel.style.marginLeft = '10px';
-      typeLabel.style.color = '#cfe8ff';
-      parent.appendChild(typeLabel);
-    }
-    const code = (Array.isArray(tileTypesById) && tileTypesById.length > selectedTileId)
-      ? (tileTypesById[selectedTileId] ?? 0)
-      : 0;
-    const name = (Array.isArray(TILE_TYPE_NAMES) && TILE_TYPE_NAMES.length)
-      ? (TILE_TYPE_NAMES[code % TILE_TYPE_NAMES.length] || 'Unknown')
-      : String(code);
-    if (typeLabel) typeLabel.textContent = 'Type: ' + name;
-  } catch(e) {}
+  // Ensure the type label prefix is present
+  const typeLabel = document.getElementById('selectedTileTypeLabel');
+  if (typeLabel) typeLabel.textContent = 'Type:';
   // Ensure single-line + smaller font for type label
   try {
     const _lbl = document.getElementById('selectedTileTypeLabel');


### PR DESCRIPTION
## Summary
- Move tile type selector next to the tile type label and remove redundant label
- Simplify selected tile type update logic

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b05e7278108333ac3c512bf8332682