### PR TITLE
Add sliders for resize controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,12 +225,18 @@
     <!-- SIZE TAB -->
     <div id="sizePanel" class="panel" style="display:none;">
       <div style="display:flex; flex-direction:column; gap:4px; margin-bottom:4px;">
-        <label for="sizeXInput" style="margin:0;">Size X</label>
-        <input type="number" id="sizeXInput" min="1" max="256" step="1" value="1" style="width:80px;">
-        <label for="sizeYInput" style="margin:0;">Size Y</label>
-        <input type="number" id="sizeYInput" min="1" max="256" step="1" value="1" style="width:80px;">
+        <div style="display:flex; align-items:center; gap:6px;">
+          <label for="sizeXInput" style="margin:0;">Size X</label>
+          <input type="number" id="sizeXInput" min="1" max="255" step="1" value="1" style="width:60px;">
+          <input type="range" id="sizeXSlider" min="1" max="255" value="1" style="flex:1;">
+        </div>
+        <div style="display:flex; align-items:center; gap:6px;">
+          <label for="sizeYInput" style="margin:0;">Size Y</label>
+          <input type="number" id="sizeYInput" min="1" max="255" step="1" value="1" style="width:60px;">
+          <input type="range" id="sizeYSlider" min="1" max="255" value="1" style="flex:1;">
+        </div>
       </div>
-      <button type="button" id="applySizeBtn" style="margin-top:4px;">Apply Size</button>
+      <button type="button" id="applySizeBtn" class="action-btn" style="margin-top:4px;">Apply</button>
     </div>
 
     <!-- OBJECTS TAB -->

--- a/js/game.js
+++ b/js/game.js
@@ -433,14 +433,42 @@ const initDom = () => {
   }
   const sizeXInput = document.getElementById('sizeXInput');
   const sizeYInput = document.getElementById('sizeYInput');
+  const sizeXSlider = document.getElementById('sizeXSlider');
+  const sizeYSlider = document.getElementById('sizeYSlider');
   const applySizeBtn = document.getElementById('applySizeBtn');
-  if (applySizeBtn && sizeXInput && sizeYInput) {
-    sizeXInput.value = mapW;
-    sizeYInput.value = mapH;
+  if (applySizeBtn && sizeXInput && sizeYInput && sizeXSlider && sizeYSlider) {
+    const syncX = (val) => {
+      const clamped = Math.max(1, Math.min(255, val));
+      sizeXInput.value = clamped;
+      sizeXSlider.value = clamped;
+    };
+    const syncY = (val) => {
+      const clamped = Math.max(1, Math.min(255, val));
+      sizeYInput.value = clamped;
+      sizeYSlider.value = clamped;
+    };
+    syncX(mapW);
+    syncY(mapH);
+    sizeXInput.addEventListener('change', () => {
+      const val = parseInt(sizeXInput.value, 10);
+      if (!isNaN(val)) syncX(val);
+    });
+    sizeXSlider.addEventListener('input', () => {
+      const val = parseInt(sizeXSlider.value, 10);
+      syncX(val);
+    });
+    sizeYInput.addEventListener('change', () => {
+      const val = parseInt(sizeYInput.value, 10);
+      if (!isNaN(val)) syncY(val);
+    });
+    sizeYSlider.addEventListener('input', () => {
+      const val = parseInt(sizeYSlider.value, 10);
+      syncY(val);
+    });
     applySizeBtn.addEventListener('click', () => {
       const newW = parseInt(sizeXInput.value, 10);
       const newH = parseInt(sizeYInput.value, 10);
-      if (!isNaN(newW) && !isNaN(newH) && newW > 0 && newH > 0 && newW <= 256 && newH <= 256) {
+      if (!isNaN(newW) && !isNaN(newH) && newW > 0 && newH > 0 && newW <= 255 && newH <= 255) {
         resizeMap(newW, newH);
       }
     });
@@ -1318,8 +1346,12 @@ async function loadMapFile(file) {
         renderTexturePalette();
         const sizeXInputEl = document.getElementById('sizeXInput');
         const sizeYInputEl = document.getElementById('sizeYInput');
+        const sizeXSliderEl = document.getElementById('sizeXSlider');
+        const sizeYSliderEl = document.getElementById('sizeYSlider');
         if (sizeXInputEl) sizeXInputEl.value = mapW;
         if (sizeYInputEl) sizeYInputEl.value = mapH;
+        if (sizeXSliderEl) sizeXSliderEl.value = mapW;
+        if (sizeYSliderEl) sizeYSliderEl.value = mapH;
       }
     }
     if (!found) {
@@ -1663,8 +1695,12 @@ function resizeMap(newW, newH) {
   mapHeights = newHeightsArr;
   const sizeXInput = document.getElementById('sizeXInput');
   const sizeYInput = document.getElementById('sizeYInput');
+  const sizeXSlider = document.getElementById('sizeXSlider');
+  const sizeYSlider = document.getElementById('sizeYSlider');
   if (sizeXInput) sizeXInput.value = newW;
   if (sizeYInput) sizeYInput.value = newH;
+  if (sizeXSlider) sizeXSlider.value = newW;
+  if (sizeYSlider) sizeYSlider.value = newH;
   resetCameraTarget(mapW, mapH, threeContainer);
   drawMap3D();
   if (highlightMesh) {


### PR DESCRIPTION
## Summary
- Add X and Y range sliders to the Resize tab with maximum 255
- Style Apply button to match other action buttons and sync slider/number inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06673ff508333b14648c58015653f