### PR TITLE
Disable Apply buttons until Draw on map mode is active

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
         <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
-        <button type="button" id="tileApplyBtn" class="action-btn">Apply</button>
+        <button type="button" id="tileApplyBtn" class="action-btn" disabled>Apply</button>
       </div>
       <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
         <button id="rotateLeft" class="rotate-btn">⟲</button>
@@ -218,7 +218,7 @@
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightSelectBtn" class="action-btn">Draw on map</button>
-        <button type="button" id="heightApplyBtn" class="action-btn">Apply</button>
+        <button type="button" id="heightApplyBtn" class="action-btn" disabled>Apply</button>
       </div>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -204,6 +204,13 @@ const initDom = () => {
   const heightApplyBtn = document.getElementById('heightApplyBtn');
   const heightBrushBtn = document.getElementById('heightBrushBtn');
 
+  const updateTileApplyBtn = () => {
+    if (tileApplyBtn) tileApplyBtn.disabled = !tileSelectionMode;
+  };
+  const updateHeightApplyBtn = () => {
+    if (heightApplyBtn) heightApplyBtn.disabled = !heightSelectionMode;
+  };
+
   const updateTileBrushControls = () => {
     const shouldEnable = tileBrushMode && !tileSelectionMode;
     if (brushInput) {
@@ -228,6 +235,8 @@ const initDom = () => {
   };
   updateTileBrushControls();
   updateHeightBrushControls();
+  updateTileApplyBtn();
+  updateHeightApplyBtn();
 
   if (tileSelectBtn) {
     tileSelectBtn.addEventListener('click', () => {
@@ -248,6 +257,7 @@ const initDom = () => {
         if (tileBrushBtn) tileBrushBtn.classList.remove('active');
         updateTileBrushControls();
       }
+      updateTileApplyBtn();
       if (lastMouseEvent) updateHighlight(lastMouseEvent);
     });
   }
@@ -270,6 +280,7 @@ const initDom = () => {
         }
       }
       updateTileBrushControls();
+      updateTileApplyBtn();
       if (lastMouseEvent) updateHighlight(lastMouseEvent);
     });
   }
@@ -320,6 +331,7 @@ const initDom = () => {
         if (heightBrushBtn) heightBrushBtn.classList.remove('active');
         updateHeightBrushControls();
       }
+      updateHeightApplyBtn();
       if (lastMouseEvent) updateHighlight(lastMouseEvent);
     });
   }
@@ -342,6 +354,7 @@ const initDom = () => {
         }
       }
       updateHeightBrushControls();
+      updateHeightApplyBtn();
       if (lastMouseEvent) updateHighlight(lastMouseEvent);
     });
   }


### PR DESCRIPTION
## Summary
- Disable tile and height Apply buttons by default
- Enable Apply buttons only when their Draw on map tool is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06eb5b4f48333a58a80ff85ace004