### PR TITLE
Highlight Apply button only after selection completes

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -149,7 +149,7 @@ function updateTileApplyBtn() {
     tileApplyBtn.classList.remove('ready');
   } else {
     tileApplyBtn.disabled = false;
-    const hasSelection = tileSelectStart && tileSelectEnd;
+    const hasSelection = tileSelectStart && tileSelectEnd && tileSelectionFixed;
     tileApplyBtn.classList.toggle('ready', !!hasSelection);
   }
 }


### PR DESCRIPTION
## Summary
- ensure tile Apply button enters ready state only after the selection is finalized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b07adf30d88333879081828a6c600c