### PR TITLE
Add cancel button for tile selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
         <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
         <button type="button" id="tileApplyBtn" class="action-btn" disabled>Apply</button>
+        <button type="button" id="tileCancelBtn" class="action-btn" disabled>Cancel</button>
       </div>
       <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
         <button id="rotateLeft" class="rotate-btn">⟲</button>

--- a/js/game.js
+++ b/js/game.js
@@ -140,6 +140,7 @@ let highlightLoadingId = null;
 let highlightLoadingRot = null;
 // References to key DOM elements so helper functions can update them
 let tileApplyBtn;
+let tileCancelBtn;
 let heightApplyBtn;
 
 function updateTileApplyBtn() {
@@ -147,10 +148,12 @@ function updateTileApplyBtn() {
   if (!tileSelectionMode) {
     tileApplyBtn.disabled = true;
     tileApplyBtn.classList.remove('ready');
+    if (tileCancelBtn) tileCancelBtn.disabled = true;
   } else {
     tileApplyBtn.disabled = false;
     const hasSelection = tileSelectStart && tileSelectEnd && tileSelectionFixed;
     tileApplyBtn.classList.toggle('ready', !!hasSelection);
+    if (tileCancelBtn) tileCancelBtn.disabled = !hasSelection;
   }
 }
 
@@ -227,6 +230,7 @@ const initDom = () => {
 
   const tileSelectBtn = document.getElementById('tileSelectBtn');
   tileApplyBtn = document.getElementById('tileApplyBtn');
+  tileCancelBtn = document.getElementById('tileCancelBtn');
   const tileBrushBtn = document.getElementById('tileBrushBtn');
   const heightSelectBtn = document.getElementById('heightSelectBtn');
   heightApplyBtn = document.getElementById('heightApplyBtn');
@@ -326,6 +330,19 @@ const initDom = () => {
         }
       }
       if (needsRedraw) drawMap3D();
+      tileSelectStart = null;
+      tileSelectEnd = null;
+      tileSelectionFixed = false;
+      if (highlightMesh && scene) {
+        scene.remove(highlightMesh);
+        highlightMesh = null;
+      }
+      updateTileApplyBtn();
+    });
+  }
+
+  if (tileCancelBtn) {
+    tileCancelBtn.addEventListener('click', () => {
       tileSelectStart = null;
       tileSelectEnd = null;
       tileSelectionFixed = false;


### PR DESCRIPTION
## Summary
- add Cancel button to tile selection toolbar
- enable Cancel only when a selection exists and clear selection on click

## Testing
- `npm test --prefix js`

------
https://chatgpt.com/codex/tasks/task_e_68b07d33a14483339eb1f6f84f327d36