### PR TITLE
Add cancel button to height editing panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,7 @@
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightSelectBtn" class="action-btn">Draw on map</button>
         <button type="button" id="heightApplyBtn" class="action-btn" disabled>Apply</button>
+        <button type="button" id="heightCancelBtn" class="action-btn" disabled>Cancel</button>
       </div>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -142,6 +142,7 @@ let highlightLoadingRot = null;
 let tileApplyBtn;
 let tileCancelBtn;
 let heightApplyBtn;
+let heightCancelBtn;
 
 function updateTileApplyBtn() {
   if (!tileApplyBtn) return;
@@ -162,10 +163,12 @@ function updateHeightApplyBtn() {
   if (!heightSelectionMode) {
     heightApplyBtn.disabled = true;
     heightApplyBtn.classList.remove('ready');
+    if (heightCancelBtn) heightCancelBtn.disabled = true;
   } else {
     heightApplyBtn.disabled = false;
     const hasSelection = heightSelectStart && heightSelectEnd;
     heightApplyBtn.classList.toggle('ready', !!hasSelection);
+    if (heightCancelBtn) heightCancelBtn.disabled = !hasSelection;
   }
 }
 const initDom = () => {
@@ -234,6 +237,7 @@ const initDom = () => {
   const tileBrushBtn = document.getElementById('tileBrushBtn');
   const heightSelectBtn = document.getElementById('heightSelectBtn');
   heightApplyBtn = document.getElementById('heightApplyBtn');
+  heightCancelBtn = document.getElementById('heightCancelBtn');
   const heightBrushBtn = document.getElementById('heightBrushBtn');
 
   const updateTileBrushControls = () => {
@@ -418,6 +422,18 @@ const initDom = () => {
         }
       }
       drawMap3D();
+      heightSelectStart = null;
+      heightSelectEnd = null;
+      if (highlightMesh && scene) {
+        scene.remove(highlightMesh);
+        highlightMesh = null;
+      }
+      updateHeightApplyBtn();
+    });
+  }
+
+  if (heightCancelBtn) {
+    heightCancelBtn.addEventListener('click', () => {
       heightSelectStart = null;
       heightSelectEnd = null;
       if (highlightMesh && scene) {


### PR DESCRIPTION
## Summary
- add a cancel button to the height tab alongside Apply
- wire up height cancel logic and control enabling

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b0809e08648333a097503fba0e92dc