### PR TITLE
Redraw map after tile type change

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -453,6 +453,7 @@ const initDom = () => {
         tileTypesById[selectedTileId] = selectedTileType;
       }
       renderTexturePalette();
+      drawMap3D();
     });
   }
   const typeToggle = document.getElementById('displayTileTypes');


### PR DESCRIPTION
## Summary
- Trigger map redraw when the selected tile's type is modified

## Testing
- `npm --prefix js test`


------
https://chatgpt.com/codex/tasks/task_e_68b08783f92083339c450e2cb019d47b