### PR TITLE
Show terrain speed modifiers as percentages

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1357,9 +1357,10 @@ function showTileTooltip(ev, idx, isTypeIndex = false) {
   const terrainKey = TILE_TYPE_CODES[typeCode];
   if (!terrainKey) return;
   let html = `<b>${TILE_TYPE_NAMES[typeCode] || ''}</b><br>`;
+  html += 'Speed modifiers:<br>';
   for (const prop in terrainSpeedModifiers) {
     const val = terrainSpeedModifiers[prop][terrainKey];
-    if (val != null) html += `${prop}: ${val}<br>`;
+    if (val != null) html += `${prop}: ${Math.round(val * 100)}%<br>`;
   }
   ensureTileTooltip();
   tileTooltipDiv.innerHTML = html;


### PR DESCRIPTION
## Summary
- Label speed modifiers in tile tooltip
- Display terrain speed modifiers as percentages instead of decimals

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0955466848333bd212fb1d17d1b2c