### PR TITLE
Show undo/redo controls and add shortcut keys

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -45,6 +45,12 @@ function showOverlay(msg){
 window.showOverlay = showOverlay;
 function hideOverlay(){
   if (overlayMsg) overlayMsg.style.display = 'none';
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.classList.remove('overlay-open');
+  }
+  if (typeof window !== 'undefined' && window.UI && typeof window.UI.showTopBar === 'function') {
+    window.UI.showTopBar(true);
+  }
 }
 // ensure single hideOverlay
 window.hideOverlay = hideOverlay;
@@ -294,6 +300,18 @@ const initDom = () => {
   if (undoBtn) undoBtn.addEventListener('click', undo);
   if (redoBtn) redoBtn.addEventListener('click', redo);
   updateUndoRedoButtons();
+
+  window.addEventListener('keydown', (e) => {
+    if (e.target && ['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
+    const key = e.key.toLowerCase();
+    if (e.ctrlKey && key === 'z' && !e.shiftKey) {
+      e.preventDefault();
+      undo();
+    } else if (e.ctrlKey && ((e.shiftKey && key === 'z') || key === 'y')) {
+      e.preventDefault();
+      redo();
+    }
+  });
 
   const updateTileBrushControls = () => {
     const shouldEnable = tileBrushMode && !tileSelectionMode;


### PR DESCRIPTION
## Summary
- reveal UI bar when overlay closes so undo/redo buttons appear
- add Ctrl+Z/Y (and Ctrl+Shift+Z) keyboard shortcuts for undo/redo

## Testing
- `npm test --prefix js`

------
https://chatgpt.com/codex/tasks/task_e_68b0b5798fc083338abb7b6c20bd4ebc