### PR TITLE
Display undo/redo shortcuts in menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,10 +144,10 @@
     <button class="tab-btn" data-tab="height">Height</button>
     <button class="tab-btn" data-tab="size">Resize</button>
     <button class="tab-btn" data-tab="objects">Structures</button>
+    <button type="button" id="undoBtn" class="tab-btn" disabled title="Undo (Ctrl+Z)">Ctrl+Z</button>
+    <button type="button" id="redoBtn" class="tab-btn" disabled title="Redo (Ctrl+Y)">Ctrl+Y</button>
   </div>
   <div id="uiBar" class="hidden">
-    <button type="button" id="undoBtn" class="tab-btn" disabled title="Undo (Ctrl+Z)">←</button>
-    <button type="button" id="redoBtn" class="tab-btn" disabled title="Redo (Ctrl+Y)">→</button>
     <span id="mapFilename"></span>
   </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -228,7 +228,7 @@ function updateHeightApplyBtn() {
 }
 const initDom = () => {
   loadTerrainSpeedModifiers();
-  document.querySelectorAll('.tab-btn').forEach(btn => {
+  document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
     btn.addEventListener('click', () => {
       const tab = btn.getAttribute('data-tab');
       setActiveTab(tab);
@@ -1131,7 +1131,7 @@ function handleMouseMove(event) {
 function setActiveTab(tab) {
   activeTab = tab;
   window.activeTab = activeTab;
-  document.querySelectorAll('.tab-btn').forEach(btn => {
+  document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
     const isActive = btn.getAttribute('data-tab') === tab;
     btn.classList.toggle('active', isActive);
   });


### PR DESCRIPTION
## Summary
- Show Undo (Ctrl+Z) and Redo (Ctrl+Y) buttons directly in the top menu after the Structures tab
- Ignore non-tab buttons when switching editor tabs to prevent unwanted tab changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c15e6e588333a78795afa641c337