### PR TITLE
Add text-based undo/redo buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
       background: #283445; color: #dde; border: 1px solid #435066;
       padding: 2px 8px; cursor: pointer; font-size: 0.9rem;
     }
-    .tab-btn.active { background: #6CF527; color: #000; }
+    .tab-btn.active:not(#undoBtn):not(#redoBtn) { background: #6CF527; color: #000; }
     .tab-btn:disabled { opacity: 0.5; }
     .rotate-btn {
       background: #283445; color: #dde; border: 1px solid #435066;
@@ -144,8 +144,8 @@
     <button class="tab-btn" data-tab="height">Height</button>
     <button class="tab-btn" data-tab="size">Resize</button>
     <button class="tab-btn" data-tab="objects">Structures</button>
-    <button type="button" id="undoBtn" class="tab-btn" disabled title="Undo (Ctrl+Z)">Ctrl+Z</button>
-    <button type="button" id="redoBtn" class="tab-btn" disabled title="Redo (Ctrl+Y)">Ctrl+Y</button>
+    <button type="button" id="undoBtn" class="tab-btn" disabled title="Undo (Ctrl+Z)">&#8630; Undo</button>
+    <button type="button" id="redoBtn" class="tab-btn" disabled title="Redo (Ctrl+Y)">&#8631; Redo</button>
   </div>
   <div id="uiBar" class="hidden">
     <span id="mapFilename"></span>

--- a/js/game.js
+++ b/js/game.js
@@ -297,8 +297,16 @@ const initDom = () => {
   const heightBrushBtn = document.getElementById('heightBrushBtn');
   undoBtn = document.getElementById('undoBtn');
   redoBtn = document.getElementById('redoBtn');
-  if (undoBtn) undoBtn.addEventListener('click', undo);
-  if (redoBtn) redoBtn.addEventListener('click', redo);
+  if (undoBtn) undoBtn.addEventListener('click', () => {
+    undo();
+    undoBtn.blur();
+    undoBtn.classList.remove('active');
+  });
+  if (redoBtn) redoBtn.addEventListener('click', () => {
+    redo();
+    redoBtn.blur();
+    redoBtn.classList.remove('active');
+  });
   updateUndoRedoButtons();
 
   window.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- Replace Ctrl+Z and Ctrl+Y menu buttons with arrow-labeled Undo and Redo options
- Prevent Undo/Redo buttons from receiving active tab styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c30f0c988333881b78c42955e287