### PR TITLE
feat: add border around tile palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,8 @@
         <span id="selectedTileTypeLabel" style="margin-left:10px; color:#cfe8ff;">Type:</span>
         <select id="tileTypeSelect"></select>
       </div>
-      <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
+      <div class="panel-box">
+        <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
         <div class="tile-options-box">
           <div class="show-hide-title">Show / Hide</div>
           <hr style="margin:4px 0;">
@@ -204,7 +205,8 @@
           </div>
           <div style="display:flex; gap:8px;">
             <label class="toggle-label"><input type="checkbox" id="displayTileTypes"> Tile type</label>
-          <label class="toggle-label"><input type="checkbox" id="showTileTypesOnMap"> Tile type in map</label>
+            <label class="toggle-label"><input type="checkbox" id="showTileTypesOnMap"> Tile type in map</label>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap texture palette and show/hide toggles in a bordered container for improved UI clarity

## Testing
- `npm test --prefix js`

------
https://chatgpt.com/codex/tasks/task_e_68b0c5daa290833388cc711e7a73bca1