### PR TITLE
Align tile palette box with brush controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,37 +176,37 @@
         <label for="tilesetSelect" style="margin:0;">Tileset:</label>
         <select id="tilesetSelect" style="flex:1;"></select>
       </div>
-      <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
-        <button type="button" id="tileBrushBtn" class="action-btn">Use Brush</button>
-        <label for="brushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
-        <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
-        <input type="range" id="brushSizeSlider" min="1" max="255" value="1" style="flex:1;">
-      </div>
-      <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
-        <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
-        <button type="button" id="tileApplyBtn" class="action-btn" disabled>Apply</button>
-        <button type="button" id="tileCancelBtn" class="action-btn" disabled>Cancel</button>
-      </div>
-      <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
-        <button id="rotateLeft" class="rotate-btn">⟲</button>
-        <button id="rotateRight" class="rotate-btn">⟳</button>
-        <span>Selected Tile: <span id="selectedTileIdDisplay">0</span></span>
-        <span id="selectedTileTypeLabel" style="margin-left:10px; color:#cfe8ff;">Type:</span>
-        <select id="tileTypeSelect"></select>
-      </div>
       <div class="panel-box">
+        <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
+          <button type="button" id="tileBrushBtn" class="action-btn">Use Brush</button>
+          <label for="brushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
+          <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
+          <input type="range" id="brushSizeSlider" min="1" max="255" value="1" style="flex:1;">
+        </div>
+        <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
+          <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
+          <button type="button" id="tileApplyBtn" class="action-btn" disabled>Apply</button>
+          <button type="button" id="tileCancelBtn" class="action-btn" disabled>Cancel</button>
+        </div>
+        <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
+          <button id="rotateLeft" class="rotate-btn">⟲</button>
+          <button id="rotateRight" class="rotate-btn">⟳</button>
+          <span>Selected Tile: <span id="selectedTileIdDisplay">0</span></span>
+          <span id="selectedTileTypeLabel" style="margin-left:10px; color:#cfe8ff;">Type:</span>
+          <select id="tileTypeSelect"></select>
+        </div>
         <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
-        <div class="tile-options-box">
-          <div class="show-hide-title">Show / Hide</div>
-          <hr style="margin:4px 0;">
-          <div style="display:flex; gap:8px; margin-bottom:4px;">
-            <label class="toggle-label"><input type="checkbox" id="showPanelIds" checked> Tile ID</label>
-            <label class="toggle-label"><input type="checkbox" id="showTileId"> Tile ID in map</label>
-          </div>
-          <div style="display:flex; gap:8px;">
-            <label class="toggle-label"><input type="checkbox" id="displayTileTypes"> Tile type</label>
-            <label class="toggle-label"><input type="checkbox" id="showTileTypesOnMap"> Tile type in map</label>
-          </div>
+      </div>
+      <div class="tile-options-box">
+        <div class="show-hide-title">Show / Hide</div>
+        <hr style="margin:4px 0;">
+        <div style="display:flex; gap:8px; margin-bottom:4px;">
+          <label class="toggle-label"><input type="checkbox" id="showPanelIds" checked> Tile ID</label>
+          <label class="toggle-label"><input type="checkbox" id="showTileId"> Tile ID in map</label>
+        </div>
+        <div style="display:flex; gap:8px;">
+          <label class="toggle-label"><input type="checkbox" id="displayTileTypes"> Tile type</label>
+          <label class="toggle-label"><input type="checkbox" id="showTileTypesOnMap"> Tile type in map</label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Rewrap brush controls and tile grid in a single panel box to start at "Use Brush" and end at the last tile
- Move Show / Hide options outside the tile palette box to avoid misalignment

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e11c867483339d3c6b06a2641cb9