### PR TITLE
Align map overlay checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,12 @@
       margin-bottom: 6px;
       border-radius: 4px;
     }
+    .toggle-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 4px 8px;
+      align-items: center;
+    }
     .panel-box {
       border: 1px solid var(--border);
       padding: 4px 8px 8px;
@@ -200,12 +206,10 @@
       <div class="tile-options-box">
         <div class="show-hide-title">Show / Hide</div>
         <hr style="margin:4px 0;">
-        <div style="display:flex; gap:8px; margin-bottom:4px;">
+        <div class="toggle-grid">
           <label class="toggle-label"><input type="checkbox" id="showPanelIds" checked> Tile ID</label>
-          <label class="toggle-label"><input type="checkbox" id="showTileId"> Tile ID in map</label>
-        </div>
-        <div style="display:flex; gap:8px;">
           <label class="toggle-label"><input type="checkbox" id="displayTileTypes"> Tile type</label>
+          <label class="toggle-label"><input type="checkbox" id="showTileId"> Tile ID in map</label>
           <label class="toggle-label"><input type="checkbox" id="showTileTypesOnMap"> Tile type in map</label>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Use grid layout to align checkbox options for tile and map overlays
- Group 'Tile ID in map' with 'Tile type in map' for clearer layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e4fb7d588333ae130d0d075817df