### PR TITLE
style: align show-hide title with tileset

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,8 +121,9 @@
     .show-hide-title {
       text-align: center;
       margin-bottom: 4px;
-      font-weight: bold;
-      color: var(--accent);
+      font-weight: normal;
+      color: var(--fg);
+      font-size: 1rem;
     }
 
     /* Overlay (initial file chooser) */
@@ -212,7 +213,6 @@
       </div>
       <div class="tile-options-box">
         <div class="show-hide-title">Show / Hide</div>
-        <hr style="margin:4px 0;">
         <div class="toggle-grid">
           <input type="checkbox" id="showPanelIds" class="toggle-btn-input" checked>
           <label for="showPanelIds" class="toggle-btn">Tile ID</label>


### PR DESCRIPTION
## Summary
- match Show/Hide title appearance to Tileset label
- remove redundant horizontal rule in tile options

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ea259d308333949c130a1ba59575