### PR TITLE
Darken dropdown hover background

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,13 @@
       white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
     }
     #fileList div:hover{ background:#283445; }
+    #editPanel select option {
+      background: var(--bg);
+    }
+    #editPanel select option:hover,
+    #editPanel select option:checked {
+      background: #283445;
+    }
     #info {
       position: absolute; right: 8px; bottom: 8px;
       background: rgba(24,32,48,0.8);


### PR DESCRIPTION
## Summary
- darken dropdown hover background in edit panel for better visibility

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b16569a1308333b2c12cb97ef2a4d0