### PR TITLE
feat: darken tile type selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,11 @@
       white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
     }
     #fileList div:hover{ background:#283445; }
+    #editPanel select {
+      background: #283445;
+      color: var(--fg);
+      border: 1px solid #435066;
+    }
     #editPanel select option {
       background: var(--bg);
     }


### PR DESCRIPTION
## Summary
- Match tile type dropdown with darker background and border

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b167528d8c83339796d76a3ce9ee17