### PR TITLE
Shorten tile label to avoid dropdown cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
         <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
           <button id="rotateLeft" class="rotate-btn">⟲</button>
           <button id="rotateRight" class="rotate-btn">⟳</button>
-          <span>Selected Tile: <span id="selectedTileIdDisplay">0</span></span>
+          <span>Tile: <span id="selectedTileIdDisplay">0</span></span>
           <span id="selectedTileTypeLabel" style="margin-left:10px; color:#cfe8ff;">Type:</span>
           <select id="tileTypeSelect"></select>
         </div>

--- a/js/game.js
+++ b/js/game.js
@@ -2323,7 +2323,7 @@ function updateHighlight(event) {
       console.warn("Unified preview failed:", err);
     });
 }
-// Ensure "Selected Tile" row uses smaller font size and stays in one line
+// Ensure "Tile" row uses smaller font size and stays in one line
 (function(){
   try {
     const idSpan = document.getElementById('selectedTileIdDisplay');


### PR DESCRIPTION
## Summary
- Shorten "Selected Tile" label to "Tile" so the tile type dropdown fits
- Update comment reflecting new label

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b169b1f5c48333be5ae9e0e9a50c5e