### PR TITLE
Reduce tile type label spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,8 +217,7 @@
         <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
           <button id="rotateLeft" class="rotate-btn">⟲</button>
           <button id="rotateRight" class="rotate-btn">⟳</button>
-          <span>Tile: <span id="selectedTileIdDisplay">0</span></span>
-          <span id="selectedTileTypeLabel" style="margin-left:10px; color:#cfe8ff;">Type:</span>
+          <span>Tile: <span id="selectedTileIdDisplay">0</span></span>&nbsp;<span id="selectedTileTypeLabel" style="color:#cfe8ff;">Type:</span>
           <select id="tileTypeSelect"></select>
         </div>
         <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>


### PR DESCRIPTION
## Summary
- remove excessive margin before tile type label and replace with a single space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b16b3da8bc833385c304fc6b4883da