### PR TITLE
fix: improve tile type select spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
       border-radius: 4px;
     }
     #tileTypeSelect {
-      width: 100px;
+      min-width: 140px;
     }
     .show-hide-title {
       text-align: center;
@@ -217,7 +217,8 @@
         <div style="display:flex; align-items:center; gap:8px; margin-bottom:4px;">
           <button id="rotateLeft" class="rotate-btn">⟲</button>
           <button id="rotateRight" class="rotate-btn">⟳</button>
-          <span>Tile: <span id="selectedTileIdDisplay">0</span></span>&nbsp;<span id="selectedTileTypeLabel" style="color:#cfe8ff;">Type:</span>
+          <span>Tile: <span id="selectedTileIdDisplay">0</span></span>
+          <span id="selectedTileTypeLabel" style="color:#cfe8ff;">Type:</span>
           <select id="tileTypeSelect"></select>
         </div>
         <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>


### PR DESCRIPTION
## Summary
- ensure tile type dropdown displays full option text
- remove extra space between tile and type labels

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b16d2e67448333b79a9b8acbea2f17