### PR TITLE
Adjust tile type dropdown width

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
       border-radius: 4px;
     }
     #tileTypeSelect {
-      min-width: 140px;
+      min-width: 120px;
     }
     .show-hide-title {
       text-align: center;


### PR DESCRIPTION
## Summary
- Reduce min-width of tile type dropdown from 140px to 120px for a narrower selector

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b16ed60cfc8333b6e5d864891a523b