### PR TITLE
Ensure numeric fields allow three-digit input

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
         <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
           <button type="button" id="tileBrushBtn" class="action-btn">Use Brush</button>
           <label for="brushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
-          <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
+          <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:72px;">
           <input type="range" id="brushSizeSlider" min="1" max="255" value="1" style="flex:1;">
         </div>
         <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
@@ -242,7 +242,7 @@
     <div id="heightPanel" class="panel" style="display:none;">
       <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
         <label for="heightValueInput" style="margin:0;">Height</label>
-        <input type="number" id="heightValueInput" value="0" min="0" max="255" style="width:60px;">
+        <input type="number" id="heightValueInput" value="0" min="0" max="255" style="width:72px;">
         <input type="range" id="heightSlider" min="0" max="255" value="0" style="flex:1;">
       </div>
       <div id="heightPresets" style="display:flex; flex-wrap:wrap; gap:4px;">
@@ -255,7 +255,7 @@
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightBrushBtn" class="action-btn">Use Brush</button>
         <label for="heightBrushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
-        <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:60px;">
+        <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:72px;">
         <input type="range" id="heightBrushSizeSlider" min="1" max="255" value="1" style="flex:1;">
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
@@ -272,12 +272,12 @@
         <div style="display:flex; flex-direction:column; gap:4px; margin-bottom:4px;">
           <div style="display:flex; align-items:center; gap:6px;">
             <label for="sizeXInput" style="margin:0;">Size X</label>
-            <input type="number" id="sizeXInput" min="1" max="255" step="1" value="1" style="width:60px;">
+            <input type="number" id="sizeXInput" min="1" max="255" step="1" value="1" style="width:72px;">
             <input type="range" id="sizeXSlider" min="1" max="255" value="1" style="flex:1;">
           </div>
           <div style="display:flex; align-items:center; gap:6px;">
             <label for="sizeYInput" style="margin:0;">Size Y</label>
-            <input type="number" id="sizeYInput" min="1" max="255" step="1" value="1" style="width:60px;">
+            <input type="number" id="sizeYInput" min="1" max="255" step="1" value="1" style="width:72px;">
             <input type="range" id="sizeYSlider" min="1" max="255" value="1" style="flex:1;">
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Expand number input widths to 72px so up to three digits display fully across brush, height, and map size controls.

## Testing
- `npm test` (repository root) *(fails: package.json missing)*
- `cd js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b170aa2e688333915703678d33f892