### PR TITLE
Reduce numeric input width to three digits

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
         <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
           <button type="button" id="tileBrushBtn" class="action-btn">Use Brush</button>
           <label for="brushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
-          <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:72px;">
+          <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:50px;">
           <input type="range" id="brushSizeSlider" min="1" max="255" value="1" style="flex:1;">
         </div>
         <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
@@ -242,7 +242,7 @@
     <div id="heightPanel" class="panel" style="display:none;">
       <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
         <label for="heightValueInput" style="margin:0;">Height</label>
-        <input type="number" id="heightValueInput" value="0" min="0" max="255" style="width:72px;">
+        <input type="number" id="heightValueInput" value="0" min="0" max="255" style="width:50px;">
         <input type="range" id="heightSlider" min="0" max="255" value="0" style="flex:1;">
       </div>
       <div id="heightPresets" style="display:flex; flex-wrap:wrap; gap:4px;">
@@ -255,7 +255,7 @@
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightBrushBtn" class="action-btn">Use Brush</button>
         <label for="heightBrushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
-        <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:72px;">
+        <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:50px;">
         <input type="range" id="heightBrushSizeSlider" min="1" max="255" value="1" style="flex:1;">
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
@@ -272,12 +272,12 @@
         <div style="display:flex; flex-direction:column; gap:4px; margin-bottom:4px;">
           <div style="display:flex; align-items:center; gap:6px;">
             <label for="sizeXInput" style="margin:0;">Size X</label>
-            <input type="number" id="sizeXInput" min="1" max="255" step="1" value="1" style="width:72px;">
+            <input type="number" id="sizeXInput" min="1" max="255" step="1" value="1" style="width:50px;">
             <input type="range" id="sizeXSlider" min="1" max="255" value="1" style="flex:1;">
           </div>
           <div style="display:flex; align-items:center; gap:6px;">
             <label for="sizeYInput" style="margin:0;">Size Y</label>
-            <input type="number" id="sizeYInput" min="1" max="255" step="1" value="1" style="width:72px;">
+            <input type="number" id="sizeYInput" min="1" max="255" step="1" value="1" style="width:50px;">
             <input type="range" id="sizeYSlider" min="1" max="255" value="1" style="flex:1;">
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Narrow numeric input fields so only three digits fit in size and height controls
- Apply same width to map size controls for consistency

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b17228f8e483338a5e8c3c29703a3b