### PR TITLE
Rearrange brush and selection controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,12 +205,14 @@
       <div class="panel-box">
         <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
           <button type="button" id="tileBrushBtn" class="action-btn">Use Brush</button>
+          <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
+        </div>
+        <div id="tileBrushControls" style="display:none; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
           <label for="brushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
           <input type="number" id="brushSizeInput" value="1" min="1" max="255" step="1" style="width:50px;">
           <input type="range" id="brushSizeSlider" min="1" max="255" value="1" style="flex:1;">
         </div>
-        <div style="display:flex; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
-          <button type="button" id="tileSelectBtn" class="action-btn">Draw on map</button>
+        <div id="tileSelectControls" style="display:none; align-items:center; gap:6px; margin-top:4px; margin-bottom:4px;">
           <button type="button" id="tileApplyBtn" class="action-btn" disabled>Apply</button>
           <button type="button" id="tileCancelBtn" class="action-btn" disabled>Cancel</button>
         </div>
@@ -254,12 +256,14 @@
       </div>
       <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightBrushBtn" class="action-btn">Use Brush</button>
+        <button type="button" id="heightSelectBtn" class="action-btn">Draw on map</button>
+      </div>
+      <div id="heightBrushControls" style="display:none; align-items:center; gap:6px; margin-top:4px;">
         <label for="heightBrushSizeInput" style="margin:0; white-space:nowrap;">Size:</label>
         <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:50px;">
         <input type="range" id="heightBrushSizeSlider" min="1" max="255" value="1" style="flex:1;">
       </div>
-      <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
-        <button type="button" id="heightSelectBtn" class="action-btn">Draw on map</button>
+      <div id="heightSelectControls" style="display:none; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightApplyBtn" class="action-btn" disabled>Apply</button>
         <button type="button" id="heightCancelBtn" class="action-btn" disabled>Cancel</button>
       </div>

--- a/js/game.js
+++ b/js/game.js
@@ -199,33 +199,39 @@ function redo() {
   updateUndoRedoButtons();
 }
 
-function updateTileApplyBtn() {
-  if (!tileApplyBtn) return;
-  if (!tileSelectionMode) {
-    tileApplyBtn.disabled = true;
-    tileApplyBtn.classList.remove('ready');
-    if (tileCancelBtn) tileCancelBtn.disabled = true;
-  } else {
-    tileApplyBtn.disabled = false;
-    const hasSelection = tileSelectStart && tileSelectEnd && tileSelectionFixed;
-    tileApplyBtn.classList.toggle('ready', !!hasSelection);
-    if (tileCancelBtn) tileCancelBtn.disabled = !hasSelection;
+  function updateTileApplyBtn() {
+    if (!tileApplyBtn) return;
+    if (tileSelectControls) {
+      tileSelectControls.style.display = tileSelectionMode ? 'flex' : 'none';
+    }
+    if (!tileSelectionMode) {
+      tileApplyBtn.disabled = true;
+      tileApplyBtn.classList.remove('ready');
+      if (tileCancelBtn) tileCancelBtn.disabled = true;
+    } else {
+      tileApplyBtn.disabled = false;
+      const hasSelection = tileSelectStart && tileSelectEnd && tileSelectionFixed;
+      tileApplyBtn.classList.toggle('ready', !!hasSelection);
+      if (tileCancelBtn) tileCancelBtn.disabled = !hasSelection;
+    }
   }
-}
 
-function updateHeightApplyBtn() {
-  if (!heightApplyBtn) return;
-  if (!heightSelectionMode) {
-    heightApplyBtn.disabled = true;
-    heightApplyBtn.classList.remove('ready');
-    if (heightCancelBtn) heightCancelBtn.disabled = true;
-  } else {
-    heightApplyBtn.disabled = false;
-    const hasSelection = heightSelectStart && heightSelectEnd;
-    heightApplyBtn.classList.toggle('ready', !!hasSelection);
-    if (heightCancelBtn) heightCancelBtn.disabled = !hasSelection;
+  function updateHeightApplyBtn() {
+    if (!heightApplyBtn) return;
+    if (heightSelectControls) {
+      heightSelectControls.style.display = heightSelectionMode ? 'flex' : 'none';
+    }
+    if (!heightSelectionMode) {
+      heightApplyBtn.disabled = true;
+      heightApplyBtn.classList.remove('ready');
+      if (heightCancelBtn) heightCancelBtn.disabled = true;
+    } else {
+      heightApplyBtn.disabled = false;
+      const hasSelection = heightSelectStart && heightSelectEnd;
+      heightApplyBtn.classList.toggle('ready', !!hasSelection);
+      if (heightCancelBtn) heightCancelBtn.disabled = !hasSelection;
+    }
   }
-}
 const initDom = () => {
   loadTerrainSpeedModifiers();
   document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
@@ -291,10 +297,14 @@ const initDom = () => {
   tileApplyBtn = document.getElementById('tileApplyBtn');
   tileCancelBtn = document.getElementById('tileCancelBtn');
   const tileBrushBtn = document.getElementById('tileBrushBtn');
+  const tileBrushControls = document.getElementById('tileBrushControls');
+  const tileSelectControls = document.getElementById('tileSelectControls');
   const heightSelectBtn = document.getElementById('heightSelectBtn');
   heightApplyBtn = document.getElementById('heightApplyBtn');
   heightCancelBtn = document.getElementById('heightCancelBtn');
   const heightBrushBtn = document.getElementById('heightBrushBtn');
+  const heightBrushControls = document.getElementById('heightBrushControls');
+  const heightSelectControls = document.getElementById('heightSelectControls');
   undoBtn = document.getElementById('undoBtn');
   redoBtn = document.getElementById('redoBtn');
   if (undoBtn) undoBtn.addEventListener('click', undo);
@@ -313,28 +323,34 @@ const initDom = () => {
     }
   });
 
-  const updateTileBrushControls = () => {
-    const shouldEnable = tileBrushMode && !tileSelectionMode;
-    if (brushInput) {
-      brushInput.disabled = !shouldEnable;
-      brushInput.style.pointerEvents = shouldEnable ? 'auto' : 'none';
-    }
-    if (brushSlider) {
-      brushSlider.disabled = !shouldEnable;
-      brushSlider.style.pointerEvents = shouldEnable ? 'auto' : 'none';
-    }
-  };
-  const updateHeightBrushControls = () => {
-    const shouldEnable = heightBrushMode && !heightSelectionMode;
-    if (heightBrushInput) {
-      heightBrushInput.disabled = !shouldEnable;
-      heightBrushInput.style.pointerEvents = shouldEnable ? 'auto' : 'none';
-    }
-    if (heightBrushSlider) {
-      heightBrushSlider.disabled = !shouldEnable;
-      heightBrushSlider.style.pointerEvents = shouldEnable ? 'auto' : 'none';
-    }
-  };
+    const updateTileBrushControls = () => {
+      const shouldEnable = tileBrushMode && !tileSelectionMode;
+      if (brushInput) {
+        brushInput.disabled = !shouldEnable;
+        brushInput.style.pointerEvents = shouldEnable ? 'auto' : 'none';
+      }
+      if (brushSlider) {
+        brushSlider.disabled = !shouldEnable;
+        brushSlider.style.pointerEvents = shouldEnable ? 'auto' : 'none';
+      }
+      if (tileBrushControls) {
+        tileBrushControls.style.display = tileBrushMode ? 'flex' : 'none';
+      }
+    };
+    const updateHeightBrushControls = () => {
+      const shouldEnable = heightBrushMode && !heightSelectionMode;
+      if (heightBrushInput) {
+        heightBrushInput.disabled = !shouldEnable;
+        heightBrushInput.style.pointerEvents = shouldEnable ? 'auto' : 'none';
+      }
+      if (heightBrushSlider) {
+        heightBrushSlider.disabled = !shouldEnable;
+        heightBrushSlider.style.pointerEvents = shouldEnable ? 'auto' : 'none';
+      }
+      if (heightBrushControls) {
+        heightBrushControls.style.display = heightBrushMode ? 'flex' : 'none';
+      }
+    };
   updateTileBrushControls();
   updateHeightBrushControls();
   updateTileApplyBtn();


### PR DESCRIPTION
## Summary
- Rework tile and height edit panels to place `Use Brush` and `Draw on map` buttons on the first row
- Show brush size inputs or apply/cancel actions on a second row only when the corresponding mode is active
- Update game logic to toggle visibility of these control rows in sync with mode changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b174acaa988333965735b906f14c39