### PR TITLE
Add Space/Escape shortcuts for selection actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,11 @@
           <li>Use <strong>WASD</strong> or arrow keys to move</li>
           <li>Press <strong>R</strong> to reset the view</li>
         </ul>
+        <p style="margin:8px 0 0 0;">Keyboard shortcuts:</p>
+        <ul style="margin:4px 0 0 20px; padding:0;">
+          <li>Press <strong>Space</strong> to apply selection</li>
+          <li>Press <strong>Esc</strong> to cancel selection</li>
+        </ul>
       </div>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -320,6 +320,20 @@ const initDom = () => {
     } else if (e.ctrlKey && ((e.shiftKey && key === 'z') || key === 'y')) {
       e.preventDefault();
       redo();
+    } else if (e.code === 'Space') {
+      e.preventDefault();
+      if (tileApplyBtn && !tileApplyBtn.disabled) {
+        tileApplyBtn.click();
+      } else if (heightApplyBtn && !heightApplyBtn.disabled) {
+        heightApplyBtn.click();
+      }
+    } else if (key === 'escape') {
+      e.preventDefault();
+      if (tileCancelBtn && !tileCancelBtn.disabled) {
+        tileCancelBtn.click();
+      } else if (heightCancelBtn && !heightCancelBtn.disabled) {
+        heightCancelBtn.click();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Support Space to apply and Esc to cancel tile/height selections
- Document the new keyboard shortcuts in the View tab

## Testing
- `cd js && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1771ba81c833386f815de3b2a1c63