### PR TITLE
Clarify drawing shortcuts with undo/redo instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,10 +193,11 @@
           <li>Use <strong>WASD</strong> or arrow keys to move</li>
           <li>Press <strong>R</strong> to reset the view</li>
         </ul>
-        <p style="margin:8px 0 0 0;">Keyboard shortcuts:</p>
+        <p style="margin:8px 0 0 0;">Draw on map:</p>
         <ul style="margin:4px 0 0 20px; padding:0;">
           <li>Press <strong>Space</strong> to apply selection</li>
           <li>Press <strong>Esc</strong> to cancel selection</li>
+          <li>Undo / redo: step back - <strong>Ctrl+Z</strong>, step forward - <strong>Ctrl+Y</strong></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Rename "Keyboard shortcuts" section to "Draw on map"
- Document undo/redo keys (Ctrl+Z and Ctrl+Y)

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b17b5d29048333b638efeb046658f1