### PR TITLE
Add show tile toggle to reveal map tile info

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,10 @@
           <label for="showPanelIds" class="toggle-btn">Tile ID</label>
           <input type="checkbox" id="displayTileTypes" class="toggle-btn-input">
           <label for="displayTileTypes" class="toggle-btn">Tile type</label>
+          <input type="checkbox" id="showTileInfo" class="toggle-btn-input">
+          <label for="showTileInfo" class="toggle-btn">Show tile</label>
+        </div>
+        <div id="tileInfoButtons" class="toggle-grid" style="display:none; margin-top:4px;">
           <input type="checkbox" id="showTileId" class="toggle-btn-input">
           <label for="showTileId" class="toggle-btn">Tile ID in map</label>
           <input type="checkbox" id="showTileTypesOnMap" class="toggle-btn-input">

--- a/js/game.js
+++ b/js/game.js
@@ -66,6 +66,9 @@ const showTileIdCheckbox = document.getElementById('showTileId');
 const showHeightCheckbox = document.getElementById('showHeight');
 // Tile types on 3D map toggle
 const showTileTypesOnMapCheckbox = document.getElementById('showTileTypesOnMap');
+// Toggle for displaying tile info buttons
+const showTileInfoCheckbox = document.getElementById('showTileInfo');
+const tileInfoButtonsDiv = document.getElementById('tileInfoButtons');
 // New: top-level map toggle for tile-type dots
 const showTileTypesCheckbox = document.getElementById('showTileTypes');
 showPanelIdsCheckbox = document.getElementById('showPanelIds');
@@ -73,6 +76,18 @@ if (showPanelIdsCheckbox) {
   showPanelIdsCheckbox.addEventListener('change', () => {
     if (typeof renderTexturePalette === 'function') renderTexturePalette();
   });
+}
+if (showTileInfoCheckbox && tileInfoButtonsDiv) {
+  const updateTileInfoVisibility = () => {
+    tileInfoButtonsDiv.style.display = showTileInfoCheckbox.checked ? 'grid' : 'none';
+    if (!showTileInfoCheckbox.checked) {
+      if (showTileIdCheckbox) showTileIdCheckbox.checked = false;
+      if (showTileTypesOnMapCheckbox) showTileTypesOnMapCheckbox.checked = false;
+      if (typeof drawMap3D === 'function') drawMap3D();
+    }
+  };
+  showTileInfoCheckbox.addEventListener('change', updateTileInfoVisibility);
+  updateTileInfoVisibility();
 }
 let STRUCTURE_DEFS = [];
 // STRUCTURE_TURRETS moved to module


### PR DESCRIPTION
## Summary
- add "Show tile" toggle in tile options panel
- show tile ID and tile type buttons only when toggle is active
- auto-hide and reset tile overlays when toggle is off

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b1964173148333bf28044248a4cb10