### PR TITLE
Fix overlay blocking menu interactions

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -39,12 +39,24 @@ function showOverlay(msg){
   } else {
     if (overlayText) overlayText.style.display = 'none';
   }
-  if (overlayMsg) overlayMsg.style.display = 'flex';
+  if (overlayMsg) {
+    overlayMsg.style.display = 'flex';
+    overlayMsg.classList.remove('hidden');
+  }
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.classList.add('overlay-open');
+  }
+  if (typeof window !== 'undefined' && window.UI && typeof window.UI.showTopBar === 'function') {
+    window.UI.showTopBar(false);
+  }
 }
 // ensure single showOverlay
 window.showOverlay = showOverlay;
 function hideOverlay(){
-  if (overlayMsg) overlayMsg.style.display = 'none';
+  if (overlayMsg) {
+    overlayMsg.style.display = 'none';
+    overlayMsg.classList.add('hidden');
+  }
   if (typeof document !== 'undefined' && document.body) {
     document.body.classList.remove('overlay-open');
   }


### PR DESCRIPTION
## Summary
- Ensure `showOverlay` adds `overlay-open` class and hides the top bar when displaying the overlay
- Ensure `hideOverlay` restores top bar visibility and removes overlay styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a03d536c8333811a56108cfedb88