### PR TITLE
Fix menu tab interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,8 @@
     #menuBar {
       position: fixed; top:0; left:0; width:100%; height:var(--menu-height);
       display:flex; align-items:center; gap:6px; padding:4px 8px;
-      background: var(--bar); border-bottom:1px solid var(--border); z-index:80; box-sizing:border-box;
+      background: var(--bar); border-bottom:1px solid var(--border); box-sizing:border-box;
+      z-index:100; pointer-events:auto;
     }
     body.overlay-open #menuBar { display:none; }
     #fileList {
@@ -78,8 +79,9 @@
       overflow-x:hidden;
     }
     #editPanel .panel {
-      width:100%; flex:1; overflow-y:auto;
+      width:100%; flex:1; overflow-y:auto; display:none;
     }
+    #viewPanel { display:block; }
     .tab-btn {
       background: #283445; color: #dde; border: 1px solid #435066;
       padding: 2px 8px; cursor: pointer; font-size: 0.9rem;
@@ -164,11 +166,11 @@
   </head>
   <body class="overlay-open">
   <div id="menuBar">
-    <button class="tab-btn" data-tab="view">View</button>
-    <button class="tab-btn" data-tab="textures">Tiles</button>
-    <button class="tab-btn" data-tab="height">Height</button>
-    <button class="tab-btn" data-tab="size">Resize</button>
-    <button class="tab-btn" data-tab="objects">Structures</button>
+    <button class="tab-btn" data-tab="view" onclick="setActiveTab('view')">View</button>
+    <button class="tab-btn" data-tab="textures" onclick="setActiveTab('textures')">Tiles</button>
+    <button class="tab-btn" data-tab="height" onclick="setActiveTab('height')">Height</button>
+    <button class="tab-btn" data-tab="size" onclick="setActiveTab('size')">Resize</button>
+    <button class="tab-btn" data-tab="objects" onclick="setActiveTab('objects')">Structures</button>
     <button type="button" id="undoBtn" class="tab-btn" disabled title="Undo (Ctrl+Z)">↺</button>
     <button type="button" id="redoBtn" class="tab-btn" disabled title="Redo (Ctrl+Y)">↻</button>
   </div>


### PR DESCRIPTION
## Summary
- Ensure tab buttons call the correct handler directly and remain clickable
- Hide non-active panels by default so tile options appear only in the Tiles tab
- Elevate menu bar z-index to sit above other UI layers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b1ac2da0833390be3e4073372f1f