### PR TITLE
use JS handlers for menu tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,11 +166,11 @@
   </head>
   <body class="overlay-open">
   <div id="menuBar">
-    <button class="tab-btn" data-tab="view" onclick="setActiveTab('view')">View</button>
-    <button class="tab-btn" data-tab="textures" onclick="setActiveTab('textures')">Tiles</button>
-    <button class="tab-btn" data-tab="height" onclick="setActiveTab('height')">Height</button>
-    <button class="tab-btn" data-tab="size" onclick="setActiveTab('size')">Resize</button>
-    <button class="tab-btn" data-tab="objects" onclick="setActiveTab('objects')">Structures</button>
+    <button type="button" class="tab-btn" data-tab="view">View</button>
+    <button type="button" class="tab-btn" data-tab="textures">Tiles</button>
+    <button type="button" class="tab-btn" data-tab="height">Height</button>
+    <button type="button" class="tab-btn" data-tab="size">Resize</button>
+    <button type="button" class="tab-btn" data-tab="objects">Structures</button>
     <button type="button" id="undoBtn" class="tab-btn" disabled title="Undo (Ctrl+Z)">↺</button>
     <button type="button" id="redoBtn" class="tab-btn" disabled title="Redo (Ctrl+Y)">↻</button>
   </div>


### PR DESCRIPTION
## Summary
- replace inline menu button handlers with JavaScript event listeners
- ensure menu tab buttons are defined as type="button" for reliable clicking

## Testing
- `cd js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b5fc2ba88333b22272888df7a997