### PR TITLE
Fix early animation reference and ensure game.js loads before UI script

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@
   <script type="module" src="js/jszip.min.js"></script>
   <script type="module" src="js/game.js"></script>
 
-<script>
+<script type="module">
     // Minimal UI bridge your game.js can use
     window.UI = {
       setMapFilename(name){ const el=document.getElementById('mapFilename'); if(el){ el.textContent = name || ''; } },

--- a/js/game.js
+++ b/js/game.js
@@ -75,6 +75,9 @@ if (showPanelIdsCheckbox) {
     if (typeof renderTexturePalette === 'function') renderTexturePalette();
   });
 }
+// Ensure animationId is defined before any calls to drawMap3D during
+// initial script execution.
+let animationId = null;
 if (showTileInfoCheckbox && tileInfoButtonsDiv) {
   const updateTileInfoVisibility = () => {
     tileInfoButtonsDiv.style.display = showTileInfoCheckbox.checked ? 'grid' : 'none';
@@ -1559,7 +1562,6 @@ function moveTileTooltip(ev) {
 function hideTileTooltip() {
   if (tileTooltipDiv) tileTooltipDiv.style.display = 'none';
 }
-let animationId = null;
 TILESETS.forEach((ts, i) => {
   let opt = document.createElement("option");
   opt.value = i;


### PR DESCRIPTION
## Summary
- Initialize `animationId` before any `drawMap3D` calls to avoid reference errors
- Load inline UI script as a module so `loadServerMap` is available when building server list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b85908d08333adb09ec5b6b7535f