### PR TITLE
Fix missing tile type toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,10 +247,6 @@
           <label for="showTileInfo" class="toggle-btn">Show tile</label>
         </div>
         <div id="tileInfoButtons" class="toggle-grid" style="display:none; margin-top:4px;">
-          <input type="checkbox" id="showTileInfo" class="toggle-btn-input">
-          <label for="showTileInfo" class="toggle-btn">Show tile</label>
-        </div>
-        <div id="tileInfoButtons" class="toggle-grid" style="display:none; margin-top:4px;">
           <input type="checkbox" id="showTileId" class="toggle-btn-input">
           <label for="showTileId" class="toggle-btn">Tile ID in map</label>
           <input type="checkbox" id="showTileTypesOnMap" class="toggle-btn-input">


### PR DESCRIPTION
## Summary
- remove duplicate tile info section so "Tile type in map" toggle appears

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21117e94c8333a75fea39b8ebb874