### PR TITLE
Add tile type overlay toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
           <input type="checkbox" id="showTileId" class="toggle-btn-input">
           <label for="showTileId" class="toggle-btn">Tile ID in map</label>
           <input type="checkbox" id="showTileTypesOnMap" class="toggle-btn-input">
-          <label for="showTileTypesOnMap" class="toggle-btn">Tile type in map</label>
+          <label for="showTileTypesOnMap" class="toggle-btn">Tile type on map</label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refine toggle label for displaying tile types directly on the map

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b2258560a08333978bb8fcd6ef2b93