### PR TITLE
Make tile info buttons depend on Show tile

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -82,11 +82,33 @@ let animationId = null;
 if (showTileInfoCheckbox && tileInfoButtonsDiv) {
   const updateTileInfoVisibility = () => {
     tileInfoButtonsDiv.style.display = showTileInfoCheckbox.checked ? 'grid' : 'none';
-    if (!showTileInfoCheckbox.checked) {
-      if (showTileIdCheckbox) showTileIdCheckbox.checked = false;
-      if (showTileTypesOnMapCheckbox) showTileTypesOnMapCheckbox.checked = false;
-      if (scene && typeof drawMap3D === 'function') drawMap3D();
-      }
+    const typeToggle = document.getElementById('displayTileTypes');
+    const disabled = !showTileInfoCheckbox.checked;
+
+    if (showTileIdCheckbox) {
+      showTileIdCheckbox.disabled = disabled;
+      if (disabled) showTileIdCheckbox.checked = false;
+    }
+    if (showTileTypesOnMapCheckbox) {
+      showTileTypesOnMapCheckbox.disabled = disabled;
+      if (disabled) showTileTypesOnMapCheckbox.checked = false;
+    }
+    const tileIdLabel = document.querySelector('label[for="showPanelIds"]');
+    if (showPanelIdsCheckbox) {
+      showPanelIdsCheckbox.disabled = disabled;
+      showPanelIdsCheckbox.style.display = disabled ? 'none' : '';
+      if (tileIdLabel) tileIdLabel.style.display = disabled ? 'none' : '';
+      if (disabled) showPanelIdsCheckbox.checked = false;
+    }
+    const typeLabel = document.querySelector('label[for="displayTileTypes"]');
+    if (typeToggle) {
+      typeToggle.disabled = disabled;
+      typeToggle.style.display = disabled ? 'none' : '';
+      if (typeLabel) typeLabel.style.display = disabled ? 'none' : '';
+      if (disabled) typeToggle.checked = false;
+    }
+    if (scene && typeof drawMap3D === 'function') drawMap3D();
+    if (typeof renderTexturePalette === 'function') renderTexturePalette();
   };
   showTileInfoCheckbox.addEventListener('change', updateTileInfoVisibility);
   updateTileInfoVisibility();


### PR DESCRIPTION
## Summary
- Link Tile ID and Tile type checkboxes to the Show tile option
- Disable and hide tile info controls when Show tile is off

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b43b4c2c14833391fa766bd966be06