### PR TITLE
Reorder tile type toggle and rename controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,17 +240,17 @@
         <div class="show-hide-title">Show / Hide</div>
         <div class="toggle-grid">
           <input type="checkbox" id="showTileInfo" class="toggle-btn-input">
-          <label for="showTileInfo" class="toggle-btn">Show tile</label>
-          <input type="checkbox" id="displayTileTypes" class="toggle-btn-input">
-          <label for="displayTileTypes" class="toggle-btn">Tile type</label>
+          <label for="showTileInfo" class="toggle-btn" style="grid-column: 1 / -1;">Show tile</label>
           <input type="checkbox" id="showPanelIds" class="toggle-btn-input" checked>
-          <label for="showPanelIds" class="toggle-btn">Tile ID</label>
+          <label for="showPanelIds" class="toggle-btn">ID</label>
+          <input type="checkbox" id="displayTileTypes" class="toggle-btn-input">
+          <label for="displayTileTypes" class="toggle-btn">Type</label>
         </div>
         <div id="tileInfoButtons" class="toggle-grid" style="display:none; margin-top:4px;">
           <input type="checkbox" id="showTileId" class="toggle-btn-input">
-          <label for="showTileId" class="toggle-btn">Tile ID in map</label>
+          <label for="showTileId" class="toggle-btn">ID on map</label>
           <input type="checkbox" id="showTileTypesOnMap" class="toggle-btn-input">
-          <label for="showTileTypesOnMap" class="toggle-btn">Tile type on map</label>
+          <label for="showTileTypesOnMap" class="toggle-btn">Type on map</label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Move Type toggle below Show tile so it aligns with ID
- Rename tile control labels for brevity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b441c62ac4833384cda9d18181c22f