### PR TITLE
Reset tile info toggles when hidden

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -109,25 +109,37 @@ if (showTileInfoCheckbox && tileInfoButtonsDiv) {
 
     if (showTileIdCheckbox) {
       showTileIdCheckbox.disabled = disabled;
-      if (disabled) showTileIdCheckbox.checked = false;
+      if (disabled) {
+        showTileIdCheckbox.checked = false;
+        showTileIdCheckbox.removeAttribute('checked');
+      }
     }
     if (showTileTypesOnMapCheckbox) {
       showTileTypesOnMapCheckbox.disabled = disabled;
-      if (disabled) showTileTypesOnMapCheckbox.checked = false;
+      if (disabled) {
+        showTileTypesOnMapCheckbox.checked = false;
+        showTileTypesOnMapCheckbox.removeAttribute('checked');
+      }
     }
     const tileIdLabel = document.querySelector('label[for="showPanelIds"]');
     if (showPanelIdsCheckbox) {
       showPanelIdsCheckbox.disabled = disabled;
       showPanelIdsCheckbox.style.display = disabled ? 'none' : '';
       if (tileIdLabel) tileIdLabel.style.display = disabled ? 'none' : '';
-      if (disabled) showPanelIdsCheckbox.checked = false;
+      if (disabled) {
+        showPanelIdsCheckbox.checked = false;
+        showPanelIdsCheckbox.removeAttribute('checked');
+      }
     }
     const typeLabel = document.querySelector('label[for="displayTileTypes"]');
     if (typeToggle) {
       typeToggle.disabled = disabled;
       typeToggle.style.display = disabled ? 'none' : '';
       if (typeLabel) typeLabel.style.display = disabled ? 'none' : '';
-      if (disabled) typeToggle.checked = false;
+      if (disabled) {
+        typeToggle.checked = false;
+        typeToggle.removeAttribute('checked');
+      }
     }
     if (scene && typeof drawMap3D === 'function') drawMap3D();
     if (typeof renderTexturePalette === 'function') renderTexturePalette();


### PR DESCRIPTION
## Summary
- reset Show tile child toggles when feature is turned off

## Testing
- `node --check js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b443efadd0833381295731b7aaae81