### PR TITLE
Reset tile info toggles when main toggle is disabled

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -110,19 +110,19 @@ if (showTileInfoCheckbox && tileInfoButtonsDiv) {
     if (showTileIdCheckbox) {
       showTileIdCheckbox.disabled = disabled;
       if (disabled) {
-        const wasChecked = showTileIdCheckbox.checked;
+        // Uncheck and trigger change so ID on map doesn't remain active
         showTileIdCheckbox.checked = false;
         showTileIdCheckbox.removeAttribute('checked');
-        if (wasChecked) showTileIdCheckbox.dispatchEvent(new Event('change'));
+        showTileIdCheckbox.dispatchEvent(new Event('change'));
       }
     }
     if (showTileTypesOnMapCheckbox) {
       showTileTypesOnMapCheckbox.disabled = disabled;
       if (disabled) {
-        const wasChecked = showTileTypesOnMapCheckbox.checked;
+        // Ensure Type on map is cleared when Show tile is off
         showTileTypesOnMapCheckbox.checked = false;
         showTileTypesOnMapCheckbox.removeAttribute('checked');
-        if (wasChecked) showTileTypesOnMapCheckbox.dispatchEvent(new Event('change'));
+        showTileTypesOnMapCheckbox.dispatchEvent(new Event('change'));
       }
     }
     const tileIdLabel = document.querySelector('label[for="showPanelIds"]');
@@ -131,10 +131,10 @@ if (showTileInfoCheckbox && tileInfoButtonsDiv) {
       showPanelIdsCheckbox.style.display = disabled ? 'none' : '';
       if (tileIdLabel) tileIdLabel.style.display = disabled ? 'none' : '';
       if (disabled) {
-        const wasChecked = showPanelIdsCheckbox.checked;
+        // Reset panel ID toggle to prevent lingering state
         showPanelIdsCheckbox.checked = false;
         showPanelIdsCheckbox.removeAttribute('checked');
-        if (wasChecked) showPanelIdsCheckbox.dispatchEvent(new Event('change'));
+        showPanelIdsCheckbox.dispatchEvent(new Event('change'));
       }
     }
     const typeLabel = document.querySelector('label[for="displayTileTypes"]');
@@ -143,10 +143,10 @@ if (showTileInfoCheckbox && tileInfoButtonsDiv) {
       typeToggle.style.display = disabled ? 'none' : '';
       if (typeLabel) typeLabel.style.display = disabled ? 'none' : '';
       if (disabled) {
-        const wasChecked = typeToggle.checked;
+        // Clear Type toggle and notify listeners
         typeToggle.checked = false;
         typeToggle.removeAttribute('checked');
-        if (wasChecked) typeToggle.dispatchEvent(new Event('change'));
+        typeToggle.dispatchEvent(new Event('change'));
       }
     }
     if (scene && typeof drawMap3D === 'function') drawMap3D();


### PR DESCRIPTION
## Summary
- Ensure sub toggles for ID, Type, ID on map and Type on map reset when the "Show tile" option is turned off
- Dispatch change events so related UI and map layers correctly clear

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b4485eb95083338fd305cecd265983