### PR TITLE
Remove obsolete Show/Hide label

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,6 @@
         <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
       </div>
       <div class="tile-options-box">
-        <div class="show-hide-title">Show / Hide</div>
         <div class="toggle-grid">
           <input type="checkbox" id="showTileInfo" class="toggle-btn-input">
           <label for="showTileInfo" class="toggle-btn" style="grid-column: 1 / -1;">Show tile</label>


### PR DESCRIPTION
## Summary
- Remove outdated "Show / Hide" label from tile options box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4551d87e4833380e669202f9dd0f8