### PR TITLE
Reduce editor sidebar width

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,13 @@
     }
     /* 3D container */
     #threeContainer {
-      position: absolute; left: 400px; top: var(--menu-height); width: calc(100vw - 400px); height: calc(100vh - var(--menu-height));
+      position: absolute; left: 320px; top: var(--menu-height); width: calc(100vw - 320px); height: calc(100vh - var(--menu-height));
       background: var(--bg); z-index: 1;
     }
     body.overlay-open #threeContainer { left: 0; width: 100vw; }
     /* Top bar (kept but minimal; can be toggled by the game) */
     #uiBar {
-      position: absolute; left: 400px; top: var(--menu-height); width: calc(100vw - 400px); z-index: 10;
+      position: absolute; left: 320px; top: var(--menu-height); width: calc(100vw - 320px); z-index: 10;
       padding: 4px 8px; background: var(--bar); border-bottom: 1px solid var(--border);
       display: flex; align-items: center; gap: 10px;
     }
@@ -73,7 +73,7 @@
 
     /* Top editor panel */
     #editPanel {
-      position:absolute; left:0; top:var(--menu-height); width:400px; height:calc(100vh - var(--menu-height));
+      position:absolute; left:0; top:var(--menu-height); width:320px; height:calc(100vh - var(--menu-height));
       background: rgba(24,32,48,0.95); padding:6px; z-index:12;
       display:flex; flex-direction:column; align-items:flex-start; gap:10px;
       overflow-x:hidden;


### PR DESCRIPTION
## Summary
- shrink editor sidebar to 320px for a slimmer layout that fits seven tiles per row

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4625c60308333a5f0d6cb22914034