### PR TITLE
Adjust tile palette spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
           <span id="selectedTileTypeLabel" style="color:#cfe8ff;">Type:</span>
           <select id="tileTypeSelect"></select>
         </div>
-        <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px;"></div>
+        <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px; justify-content:center;"></div>
       </div>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -99,7 +99,7 @@ const TILE_TYPE_COLORS = [
   '#8a2be2',
   '#00ced1'
 ];
-const TILE_ICON_SIZE = 40;
+const TILE_ICON_SIZE = 38;
 // Ensure animationId is defined before any calls to drawMap3D during
 // initial script execution.
 let animationId = null;


### PR DESCRIPTION
## Summary
- Reduce tile icon size for texture palette
- Center texture palette tiles for even side spacing

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b469d41bd483338d086f9272b4ca09