### PR TITLE
Left-align texture palette and enlarge tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
           <span id="selectedTileTypeLabel" style="color:#cfe8ff;">Type:</span>
           <select id="tileTypeSelect"></select>
         </div>
-        <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px; justify-content:center;"></div>
+        <div id="texturePalette" style="display:flex; flex-wrap:wrap; gap:2px; justify-content:flex-start;"></div>
       </div>
     </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -99,7 +99,7 @@ const TILE_TYPE_COLORS = [
   '#8a2be2',
   '#00ced1'
 ];
-const TILE_ICON_SIZE = 38;
+const TILE_ICON_SIZE = 42;
 // Ensure animationId is defined before any calls to drawMap3D during
 // initial script execution.
 let animationId = null;


### PR DESCRIPTION
## Summary
- Align texture palette to the left instead of centered
- Increase tile icon size from 38px to 42px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b46e61b2d48333a52b4b87159d7b53