### PR TITLE
Reduce tile icon size to 41px

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -99,7 +99,7 @@ const TILE_TYPE_COLORS = [
   '#8a2be2',
   '#00ced1'
 ];
-const TILE_ICON_SIZE = 42;
+const TILE_ICON_SIZE = 41;
 // Ensure animationId is defined before any calls to drawMap3D during
 // initial script execution.
 let animationId = null;


### PR DESCRIPTION
## Summary
- decrease tile icon size constant from 42px to 41px

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b471f7453c8333bf9a825c2d10d5fc