### PR TITLE
Sync tile preview with camera rotation

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1408,7 +1408,7 @@ function renderTexturePalette() {
     if (img && img.complete && img.naturalWidth > 0) {
       ctx.save();
       ctx.translate(center, center);
-      ctx.rotate((selectedRotation * Math.PI) / 2);
+      ctx.rotate(cameraState.rotationY + (selectedRotation * Math.PI) / 2);
       ctx.translate(-center, -center);
       ctx.drawImage(img, 0, 0, TILE_ICON_SIZE, TILE_ICON_SIZE);
       ctx.restore();
@@ -1886,6 +1886,7 @@ function drawMap3D() {
       cameraState.rotationX -= dy * 0.008;
       cameraState.rotationX = Math.max(-1.1, Math.min(-0.08, cameraState.rotationX));
       lastX = e.clientX; lastY = e.clientY;
+      renderTexturePalette();
     });
     threeContainer.addEventListener('wheel', e => {
       cameraState.zoom *= (1 + e.deltaY * 0.0015);


### PR DESCRIPTION
## Summary
- Rotate tile palette tiles by the current camera yaw so previews match map orientation
- Refresh tile palette while dragging to update rotation live

## Testing
- `cd js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b47a4d31d8833392b65b3ec8f4396c