### PR TITLE
Add compass overlay to map viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,10 +65,21 @@
       background: #283445;
     }
     #info {
-      position: absolute; right: 8px; bottom: 8px;
+      position: absolute; right: 8px; bottom: 80px;
       background: rgba(24,32,48,0.8);
       padding:8px; border-radius:5px;
       z-index:50;
+    }
+
+    #compass {
+      position: absolute; right: 8px; bottom: 8px;
+      width: 60px; height: 60px;
+      z-index: 50;
+      pointer-events: none;
+    }
+
+    #compass svg {
+      width: 100%; height: 100%;
     }
 
     /* Top editor panel */
@@ -326,6 +337,15 @@
   <div id="threeContainer"></div>
   <div id="fileList" class="hidden"></div>
   <div id="info"></div>
+  <div id="compass">
+    <svg viewBox="0 0 100 100">
+      <circle cx="50" cy="50" r="48" stroke="#435066" stroke-width="2" fill="rgba(24,32,48,0.8)" />
+      <g id="compassNeedle">
+        <polygon points="50,20 60,60 50,50 40,60" fill="#6cf" />
+      </g>
+      <text x="50" y="94" text-anchor="middle" fill="#dde" font-size="20">N</text>
+    </svg>
+  </div>
 
   <!-- Overlay -->
   <div id="overlayMsg">

--- a/js/game.js
+++ b/js/game.js
@@ -22,6 +22,7 @@ import { buildStructureGroup } from "./structureGroup.js";
 const tilesetSelect = document.getElementById('tilesetSelect');
 const fileListDiv = document.getElementById('fileList');
 const infoDiv = document.getElementById('info');
+const compassNeedle = document.getElementById('compassNeedle');
 const mapFilenameSpan = document.getElementById('mapFilename');
 const uiBar = document.getElementById('uiBar');
 const threeContainer = document.getElementById('threeContainer');
@@ -2053,6 +2054,10 @@ function updateCulling() {
     camera.position.y = camY;
     camera.position.z = cameraState.camTargetZ + Math.cos(cameraState.rotationY) * Math.cos(cameraState.rotationX) * dist;
     camera.lookAt(cameraState.camTargetX, 0, cameraState.camTargetZ);
+    if (compassNeedle) {
+      const deg = -cameraState.rotationY * 180 / Math.PI;
+      compassNeedle.setAttribute('transform', `rotate(${deg} 50 50)`);
+    }
     updateCulling();
     renderer.render(scene, camera);
     animationId = requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- Add SVG-based compass overlay to the viewer
- Update camera loop to rotate compass with camera orientation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b47f6ef8cc8333b37ec31a2cee877e