### PR TITLE
Move compass to top-right corner

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
     }
 
     #compass {
-      position: absolute; right: 8px; bottom: 8px;
+      position: absolute; right: 8px; top: 8px;
       width: 60px; height: 60px;
       z-index: 50;
       pointer-events: none;


### PR DESCRIPTION
## Summary
- Relocate the compass overlay to the top-right of the viewport to avoid overlapping bottom UI elements.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b48470462c8333b7d858ffea6a1989