### PR TITLE
Adjust compass position below menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,10 +72,14 @@
     }
 
     #compass {
-      position: absolute; right: 8px; top: 8px;
+      position: absolute; right: 8px; top: calc(var(--menu-height) + 8px);
       width: 60px; height: 60px;
       z-index: 50;
       pointer-events: none;
+    }
+
+    body.overlay-open #compass {
+      top: 8px;
     }
 
     #compass svg {


### PR DESCRIPTION
## Summary
- position compass below the top menu to keep it fully visible
- allow compass to return to top when overlay is open

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4860b64208333b339579be807f7cb