### PR TITLE
Fix tile selection ignoring clicks after camera rotation refresh

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1883,8 +1883,10 @@ function drawMap3D() {
       lastY = e.clientY;
     });
     window.addEventListener('mouseup', () => {
-      isDragging = false;
-      renderTexturePalette();
+      if (isDragging) {
+        isDragging = false;
+        renderTexturePalette();
+      }
     });
     window.addEventListener('mousemove', e => {
       if (!isDragging) return;


### PR DESCRIPTION
## Summary
- Only refresh texture palette after camera drag is released

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b48fea92d48333807f165f5db935ad