### PR TITLE
Reorder height controls and style presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,18 +270,6 @@
     <!-- HEIGHT TAB -->
     <div id="heightPanel" class="panel" style="display:none;">
       <div style="display:flex; align-items:center; gap:6px; margin-bottom:4px;">
-        <label for="heightValueInput" style="margin:0;">Height</label>
-        <input type="number" id="heightValueInput" value="0" min="0" max="255" style="width:50px;">
-        <input type="range" id="heightSlider" min="0" max="255" value="0" style="flex:1;">
-      </div>
-      <div id="heightPresets" style="display:flex; flex-wrap:wrap; gap:4px;">
-        <button type="button" class="height-preset" data-val="0">0</button>
-        <button type="button" class="height-preset" data-val="64">64</button>
-        <button type="button" class="height-preset" data-val="128">128</button>
-        <button type="button" class="height-preset" data-val="192">192</button>
-        <button type="button" class="height-preset" data-val="255">255</button>
-      </div>
-      <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightBrushBtn" class="action-btn">Use Brush</button>
         <button type="button" id="heightSelectBtn" class="action-btn">Draw on map</button>
         <button type="button" id="showHeightBtn" class="action-btn">Show Heights</button>
@@ -290,6 +278,18 @@
         <label for="heightBrushSizeInput" style="margin:0; white-space:nowrap;">Square size:</label>
         <input type="number" id="heightBrushSizeInput" value="1" min="1" max="255" step="1" style="width:50px;">
         <input type="range" id="heightBrushSizeSlider" min="1" max="255" value="1" style="flex:1;">
+      </div>
+      <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
+        <label for="heightValueInput" style="margin:0;">Height</label>
+        <input type="number" id="heightValueInput" value="0" min="0" max="255" style="width:50px;">
+        <input type="range" id="heightSlider" min="0" max="255" value="0" style="flex:1;">
+      </div>
+      <div id="heightPresets" style="display:flex; flex-wrap:wrap; gap:4px; margin-top:4px;">
+        <button type="button" class="action-btn height-preset" data-val="0">0</button>
+        <button type="button" class="action-btn height-preset" data-val="64">64</button>
+        <button type="button" class="action-btn height-preset" data-val="128">128</button>
+        <button type="button" class="action-btn height-preset" data-val="192">192</button>
+        <button type="button" class="action-btn height-preset" data-val="255">255</button>
       </div>
       <div id="heightSelectControls" style="display:none; justify-content:center; align-items:center; gap:6px; margin-top:4px;">
         <button type="button" id="heightApplyBtn" class="action-btn" disabled>Apply</button>


### PR DESCRIPTION
## Summary
- Move height slider and preset controls below brush size settings in the height panel
- Style height preset buttons with action-button look for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49527d0bc83338908bb4b0ba7969e