### PR TITLE
Add undo/redo support for structure placement

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -282,6 +282,15 @@ function applyAction(action, mode) {
   } else if (action.type === 'resize') {
     const state = mode === 'undo' ? action.oldState : action.newState;
     setMapState(state.w, state.h, state.tiles, state.rotations, state.heights);
+  } else if (action.type === 'structure') {
+    if (mode === 'undo') {
+      objectsGroup.remove(action.group);
+      drawMap3D();
+    } else {
+      objectsGroup.add(action.group);
+      if (!scene.children.includes(objectsGroup)) scene.add(objectsGroup);
+      drawMap3D();
+    }
   }
 }
 
@@ -1009,6 +1018,7 @@ function handleEditClick(event) {
       objectsGroup.add(group);
       if (!scene.children.includes(objectsGroup)) scene.add(objectsGroup);
       drawMap3D();
+      pushUndo({ type: 'structure', group });
     }).catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary
- Track structure placements in the undo stack
- Restore or remove structure groups when undoing or redoing

## Testing
- `npm test --prefix js`

------
https://chatgpt.com/codex/tasks/task_e_68b4c4a480d883338b1844b2276bf974