### PR TITLE
Add structure type filter dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,6 +323,10 @@
     <!-- OBJECTS TAB -->
     <div id="objectsPanel" class="panel" style="display:none;">
       <div style="margin-bottom:4px;">
+        <label for="structureFilter" style="margin:0; display:block;">Type:</label>
+        <select id="structureFilter" style="width:100%; font-size:0.9rem;"></select>
+      </div>
+      <div style="margin-bottom:4px;">
         <label for="structureSelect" style="margin:0; display:block;">Structure:</label>
         <select id="structureSelect" size="8" style="width:100%; font-size:0.9rem;"></select>
       </div>


### PR DESCRIPTION
## Summary
- Add structure type dropdown to objects panel
- Implement filtering logic and categories for structures

## Testing
- `npm --prefix js test`

------
https://chatgpt.com/codex/tasks/task_e_68b4cc9dc14c83339e1c1e1190a699ec