### PR TITLE
feat: add sensors structures category

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -149,6 +149,7 @@ let previewLoadToken = 0;
 let highlightLoadToken = 0;
 const STRUCTURE_CATEGORY_NAMES = [
   'Base buildings',
+  'Sensors',
   'Walls',
   'Towers',
   'Bunkers',
@@ -204,8 +205,7 @@ async function loadStructureDefs() {
         type: entry.type || '',
         strength: entry.strength || '',
         combinesWithWall: !!entry.combinesWithWall
-      }))
-      .filter(def => !SENSOR_STRUCTURE_IDS.has(def.id.toLowerCase()));
+      }));
     populateStructureSelect();
   } catch (err) {
     console.error('Failed to load structure definitions:', err);
@@ -232,16 +232,17 @@ function categorizeStructure(def) {
     return 'Base buildings';
   }
 
-  if (type !== 'defense') {
-    return 'Unavailable buildings';
-  }
-
   if (
+    SENSOR_STRUCTURE_IDS.has(id) ||
     name.includes('sensor') ||
     name.includes('satellite') ||
     name.includes('radar') ||
     name.includes('cb tower')
   ) {
+    return 'Sensors';
+  }
+
+  if (type !== 'defense') {
     return 'Unavailable buildings';
   }
 


### PR DESCRIPTION
## Summary
- add "Sensors" category for structure types
- include sensor structures in the definitions and categorize them correctly

## Testing
- `node --check js/game.js`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d97746fc8333b70101b916d98cf1