### PR TITLE
Include corner walls in Walls structure category

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -246,7 +246,7 @@ function categorizeStructure(def) {
     return 'Unavailable buildings';
   }
 
-  if (type === 'wall' || type === 'gate' || name.includes('tank trap')) {
+  if (type === 'wall' || type === 'gate' || type === 'corner wall' || name.includes('tank trap')) {
     return 'Walls';
   }
 


### PR DESCRIPTION
## Summary
- Ensure structures classified as `CORNER WALL` appear under the Walls tab

## Testing
- `cd js && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e042332c8333936883c5884d7a15