### PR TITLE
Ensure walls appear in structure list

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -242,12 +242,12 @@ function categorizeStructure(def) {
     return 'Sensors';
   }
 
-  if (type !== 'defense') {
-    return 'Unavailable buildings';
-  }
-
   if (type === 'wall' || type === 'gate' || type === 'corner wall' || name.includes('tank trap')) {
     return 'Walls';
+  }
+
+  if (type !== 'defense') {
+    return 'Unavailable buildings';
   }
 
   if (type === 'fortress') {


### PR DESCRIPTION
## Summary
- Fix structure categorization so wall structures appear under the "Walls" filter.

## Testing
- `node --check js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e25f8db483339433709f9d87ecd3