### PR TITLE
Restrict wall selection to hardcrete and tank traps

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -188,6 +188,13 @@ const SENSOR_STRUCTURE_IDS = new Set([
   'a0sat-linkcentre'
 ]);
 
+const WALL_STRUCTURE_IDS = new Set([
+  'a0tanktrap',
+  'a0hardcretemk1cwall',
+  'a0hardcretemk1wall',
+  'a0hardcretemk1gate'
+]);
+
 
 async function loadStructureDefs() {
   try {
@@ -242,7 +249,7 @@ function categorizeStructure(def) {
     return 'Sensors';
   }
 
-  if (type === 'wall' || type === 'gate' || type === 'corner wall' || name.includes('tank trap')) {
+  if (WALL_STRUCTURE_IDS.has(id)) {
     return 'Walls';
   }
 


### PR DESCRIPTION
## Summary
- Limit Walls category to Hardcrete Corner Wall, Hardcrete Wall, Hardcrete Gate, and Tank Traps
- Introduce wall ID whitelist and adjust categorization logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e62fbfc0833387fd8964ba1a95a1