### PR TITLE
Fix bunker categorization

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -275,7 +275,7 @@ function categorizeStructure(def) {
     return 'Hardpoints';
   }
 
-  if (strength === 'bunker' || name.includes('bunker')) {
+  if (name.includes('bunker')) {
     return 'Bunkers';
   }
 


### PR DESCRIPTION
## Summary
- ensure only structures with "bunker" in their name are grouped as bunkers

## Testing
- `npm test --prefix js`

------
https://chatgpt.com/codex/tasks/task_e_68b4eb8cd44883338a18883932092087