### PR TITLE
Add turret model for Heavy Machinegun Bunker

### DIFF
--- a/js/structure_turrets.js
+++ b/js/structure_turrets.js
@@ -66,7 +66,7 @@ export const STRUCTURE_TURRETS = {
   "P0-AASite-SAM2": ['gnhmslsa.pie', 'trhmslsa.pie'],
   "P0-AASite-Sunburst": ['gnmair3.pie', 'trmair3.pie'],
   "PillBox-Cannon6": ['gnhvcan2.pie', 'trhvcan2.pie'],
-  "PillBox1": [],
+  "PillBox1": ['gnmmg1.pie', 'trmmg.pie'],
   "PillBox4": ['gnlcan.pie', 'trlcan.pie'],
   "PillBox5": ['gnlflmr.pie', 'trlflmr.pie'],
   "Pillbox-RotMG": [],


### PR DESCRIPTION
## Summary
- Add missing turret PIE models for Heavy Machinegun Bunker so it renders correctly in bunker structures

## Testing
- `node -e "import('./js/structure_turrets.js').then(()=>console.log('loaded')).catch(err=>{console.error(err);process.exit(1);})"`


------
https://chatgpt.com/codex/tasks/task_e_68b4eccdd5c483338c99740073e7b575