### PR TITLE
Allow Twin Assault Cannon Bunker

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -209,6 +209,7 @@ const ALLOWED_BUNKER_IDS = new Set([
   'pillbox1',
   'pillbox5',
   'pillbox4',
+  'pillbox-cannon6',
   'tower-projector',
   'pillbox-rotmg',
   'plasmite-flamer-bunker'


### PR DESCRIPTION
## Summary
- include Twin Assault Cannon Bunker in allowed bunker IDs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5421c28508333a9699abae87a5705