### PR TITLE
Populate sensor structure list and exclude laser satellite command post

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -202,7 +202,14 @@ const ALLOWED_TOWER_IDS = new Set([
   'guardtower-rail1',
   'guardtower-atmiss',
   'sys-spytower',
-  'guardtower-beamlas'
+  'guardtower-beamlas',
+  'sys-sensotower01',
+  'sys-sensotower02',
+  'sys-radardetector01',
+  'sys-cb-tower01',
+  'sys-vtol-radartower01',
+  'sys-vtol-cb-tower01',
+  'sys-sensotowerws'
 ]);
 
 const ALLOWED_BUNKER_IDS = new Set([
@@ -260,11 +267,13 @@ function categorizeStructure(def) {
   }
 
   if (
-    SENSOR_STRUCTURE_IDS.has(id) ||
-    name.includes('sensor') ||
-    name.includes('satellite') ||
-    name.includes('radar') ||
-    name.includes('cb tower')
+    id !== 'a0lassatcommand' && (
+      SENSOR_STRUCTURE_IDS.has(id) ||
+      name.includes('sensor') ||
+      name.includes('satellite') ||
+      name.includes('radar') ||
+      name.includes('cb tower')
+    )
   ) {
     return 'Sensors';
   }


### PR DESCRIPTION
## Summary
- add sensor tower IDs so all sensor structures appear in the Structures tab
- exclude Laser Satellite Command Post from the Sensors category

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b5446f033883339e12ea41ec86049d