### PR TITLE
feat: allow Assault Cannon Hardpoint

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -224,6 +224,7 @@ const ALLOWED_BUNKER_IDS = new Set([
 
 const ALLOWED_HARDPOINT_IDS = new Set([
   'wall-rotmg',
+  'wall-vulcancan',
   'walltower-doubleaagun',
   'walltower-hpvcannon',
   'walltower-hvatrocket',


### PR DESCRIPTION
## Summary
- allow `Wall-VulcanCan` (Assault Cannon Hardpoint) to be displayed by adding it to allowed hardpoint IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54bdadb488333a8e85e0ff7734e4b