### PR TITLE
Add AA Tornado Flak Cannon hardpoint ID

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -226,6 +226,7 @@ const ALLOWED_HARDPOINT_IDS = new Set([
   'wall-rotmg',
   'wall-vulcancan',
   'walltower-doubleaagun',
+  'walltower-doubleaagun02',
   'walltower-hpvcannon',
   'walltower-hvatrocket',
   'walltower-pulselas',


### PR DESCRIPTION
## Summary
- include WallTower-DoubleAAGun02 in allowed hardpoint IDs

## Testing
- `node --check js/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b54e7611fc8333a7886fa1feb2293a