### PR TITLE
Include Avenger Hardpoint in allowed hardpoint list

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -234,6 +234,7 @@ const ALLOWED_HARDPOINT_IDS = new Set([
   'walltower-rail2',
   'walltower-rail3',
   'walltower-samhvy',
+  'walltower-samsite',
   'walltower-twinassaultgun',
   'walltower-atmiss',
   'walltower-emp',


### PR DESCRIPTION
## Summary
- allow Avenger Hardpoint (walltower-samsite) structures by adding its ID to the hardpoint whitelist

## Testing
- `cd js && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54feabc7483339ed86242d61082ee