### PR TITLE
Move Satellite Uplink Center to base buildings

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -174,7 +174,8 @@ const BASE_STRUCTURE_IDS = new Set([
   'a0vtolfactory1',
   'a0repaircentre3',
   'a0vtolpad',
-  'a0resourceextractor'
+  'a0resourceextractor',
+  'a0sat-linkcentre'
 ]);
 
 const SENSOR_STRUCTURE_IDS = new Set([
@@ -184,8 +185,7 @@ const SENSOR_STRUCTURE_IDS = new Set([
   'sys-cb-tower01',
   'sys-vtol-radartower01',
   'sys-vtol-cb-tower01',
-  'sys-sensotowerws',
-  'a0sat-linkcentre'
+  'sys-sensotowerws'
 ]);
 
 const WALL_STRUCTURE_IDS = new Set([


### PR DESCRIPTION
## Summary
- classify Satellite Uplink Center as a base building instead of a sensor

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b561f0b36c8333a8245e23663cf28c