### PR TITLE
Add Laser Satellite Command Post to base building list

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -175,7 +175,8 @@ const BASE_STRUCTURE_IDS = new Set([
   'a0repaircentre3',
   'a0vtolpad',
   'a0resourceextractor',
-  'a0sat-linkcentre'
+  'a0sat-linkcentre',
+  'a0lassatcommand'
 ]);
 
 const SENSOR_STRUCTURE_IDS = new Set([
@@ -288,7 +289,6 @@ const ALLOWED_OTHER_DEFENSE_IDS = new Set([
   'emplacement-prislas',
   'emplacement-heavylaser',
   'emplacement-rail2',
-  'a0lassatcommand',
   'emplacement-rail3'
 ]);
 
@@ -412,13 +412,11 @@ function categorizeStructure(def) {
   }
 
   if (
-    id !== 'a0lassatcommand' && (
-      SENSOR_STRUCTURE_IDS.has(id) ||
-      name.includes('sensor') ||
-      name.includes('satellite') ||
-      name.includes('radar') ||
-      name.includes('cb tower')
-    )
+    SENSOR_STRUCTURE_IDS.has(id) ||
+    name.includes('sensor') ||
+    name.includes('satellite') ||
+    name.includes('radar') ||
+    name.includes('cb tower')
   ) {
     return 'Sensors';
   }


### PR DESCRIPTION
## Summary
- Move Laser Satellite Command Post into the Base buildings category
- Remove Laser Satellite Command Post from the Other defenses category and simplify sensor classification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5647c566c8333adc154c89b3756a6