### PR TITLE
Render floors for base structures

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -390,7 +390,10 @@ async function loadStructureDefs() {
         name: entry.name,
         sizeX: entry.width,
         sizeY: entry.breadth,
-        pies: entry.structureModel,
+        pies: [
+          ...(entry.baseModel ? [entry.baseModel] : []),
+          ...(entry.structureModel || [])
+        ],
         type: entry.type || '',
         strength: entry.strength || '',
         combinesWithWall: !!entry.combinesWithWall,


### PR DESCRIPTION
## Summary
- Load `baseModel` for structures and prepend it to the geometry list so base buildings display their floor tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b6b5dc748333a4b73daa670e755b