### PR TITLE
fix: show building base floors

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -400,6 +400,11 @@ async function loadStructureDefs() {
           : (entry.structureModel ? [entry.structureModel] : []);
         const nonModules = models.filter(m => !/module/i.test(m));
         if (nonModules.length) {
+          // Include the optional floor/base model first so the structure
+          // sits on top of it, then add the main building geometry.
+          if (entry.baseModel) {
+            pies.push(entry.baseModel);
+          }
           pies.push(nonModules[0]);
         } else if (entry.baseModel) {
           pies.push(entry.baseModel);


### PR DESCRIPTION
## Summary
- render optional baseModel along with main structure to restore building floors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5df8462f48333a1d20b7970315c9b