### PR TITLE
Add fallback structure connectors for towers

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1670,6 +1670,12 @@ function __old_updateHighlight(event) {
             y: cyScaled - minYVal,
             z: czScaled - cZ
           };
+        } else {
+          connRel = {
+            x: 0,
+            y: bb2.max.y - minYVal,
+            z: 0
+          };
         }
         const inner = new THREE.Group();
         const baseMesh = new THREE.Mesh(g, baseMat);

--- a/js/structureGroup.js
+++ b/js/structureGroup.js
@@ -74,13 +74,21 @@ export async function buildStructureGroup(def, rotation, sizeX, sizeY, scaleOver
   const topGeo = baseGeos[topIdx];
   const topC = blockCenters[topIdx];
   let connectorPos = null;
+  const topBBox = topGeo.boundingBox;
   if (topGeo.userData && topGeo.userData.connectors && topGeo.userData.connectors.length) {
     let bc = topGeo.userData.connectors[0];
-    const minY = topGeo.boundingBox ? topGeo.boundingBox.min.y : 0;
+    const minY = topBBox ? topBBox.min.y : 0;
     connectorPos = {
       x: bc.x * scale - topC.cX,
       y: bc.y * scale - minY,
       z: bc.z * scale - topC.cZ
+    };
+  } else if (topBBox) {
+    const minY = topBBox.min.y;
+    connectorPos = {
+      x: 0,
+      y: topBBox.max.y - minY,
+      z: 0
     };
   }
   let attachments = STRUCTURE_TURRETS[def.id];


### PR DESCRIPTION
## Summary
- Default structure connector position to model top center when no connector data exists
- Use the fallback connector for build preview to properly place tower turrets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b868b18938833390527c7848478447