### PR TITLE
Switch rotations to clockwise orientation

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -1726,7 +1726,7 @@ function __old_updateHighlight(event) {
           const pY = maxH2 + 0.02 - minYVal;
           const pZ = tileY + sizeY / 2 - cZ;
           inner.position.set(pX + cX, pY, pZ + cZ);
-          inner.rotation.y = selectedStructureRotation * Math.PI / 2;
+          inner.rotation.y = -selectedStructureRotation * Math.PI / 2;
           inner.userData.centerX = cX;
           inner.userData.centerY = cY;
           inner.userData.centerZ = cZ;
@@ -1891,8 +1891,8 @@ function renderTexturePalette() {
     if (img && img.complete && img.naturalWidth > 0) {
       ctx.save();
       ctx.translate(center, center);
-      const snapped = Math.round(cameraState.rotationY / (Math.PI / 2)) * (Math.PI / 2);
-      ctx.rotate(snapped + (selectedRotation * Math.PI) / 2);
+        const snapped = Math.round(cameraState.rotationY / (Math.PI / 2)) * (Math.PI / 2);
+        ctx.rotate(snapped - (selectedRotation * Math.PI) / 2);
       ctx.translate(-center, -center);
       ctx.drawImage(img, 0, 0, TILE_ICON_SIZE, TILE_ICON_SIZE);
       ctx.restore();
@@ -2506,9 +2506,9 @@ try {
       new THREE.MeshLambertMaterial({ color: 0x393, side: THREE.DoubleSide });
     const instancedMesh = new THREE.InstancedMesh(tileGeometry, material, positions.length);
     positions.forEach((pos, i) => {
-      const h = Math.max(pos.h * HEIGHT_SCALE, 0.01);
-      const rotation = (mapRotations[pos.y][pos.x] % 4) * Math.PI / 2;
-      const matrix = new THREE.Matrix4();
+        const h = Math.max(pos.h * HEIGHT_SCALE, 0.01);
+        const rotation = -(mapRotations[pos.y][pos.x] % 4) * Math.PI / 2;
+        const matrix = new THREE.Matrix4();
       const rotationMatrix = new THREE.Matrix4().makeRotationY(rotation);
       const scaleMatrix = new THREE.Matrix4().makeScale(1, h, 1);
       const translationMatrix = new THREE.Matrix4().makeTranslation(pos.x + 0.5, h / 2, pos.y + 0.5);

--- a/js/structureGroup.js
+++ b/js/structureGroup.js
@@ -83,9 +83,9 @@ export async function buildStructureGroup(def, rotation, sizeX, sizeY, scaleOver
       gMesh.position.set(-gcX, -gunBottom, -gcZ);
       tMesh.add(gMesh);
     }
-  }
-  group.rotation.y = rotation * Math.PI / 2;
-  group.updateMatrixWorld(true);
+    }
+    group.rotation.y = -rotation * Math.PI / 2;
+    group.updateMatrixWorld(true);
   let bbox = new THREE.Box3().setFromObject(group);
   const minY = bbox.min.y;
   group.userData.minY = minY;


### PR DESCRIPTION
## Summary
- interpret tile rotation indices as clockwise
- rotate tile previews and structure placement using negative angles
- apply clockwise rotation within shared structure group builder

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87e2f1ca48333891d500239131085