### PR TITLE
feat: convert gamma maps on load

### DIFF
--- a/js/convert.js
+++ b/js/convert.js
@@ -1,0 +1,51 @@
+// Convert Gamma-style game.map data to classic 3-byte-per-tile map format.
+// Based on gamma_to_classic.py
+
+export function convertGammaGameMapToClassic(gammaData) {
+  if (!gammaData || gammaData.length < 12) return null;
+  if (
+    gammaData[0] !== 0x6d || // m
+    gammaData[1] !== 0x61 || // a
+    gammaData[2] !== 0x70 || // p
+    gammaData[3] !== 0x20 || // space
+    gammaData[4] !== 0x28    // '('
+  ) {
+    return null; // not Gamma style
+  }
+
+  const dv = new DataView(
+    gammaData.buffer,
+    gammaData.byteOffset,
+    gammaData.byteLength
+  );
+  const width = dv.getInt32(4, true);
+  const height = dv.getInt32(8, true);
+  if (width <= 0 || height <= 0) return null;
+  const tiles = width * height;
+  const gridIn = new DataView(
+    gammaData.buffer,
+    gammaData.byteOffset + 12,
+    tiles * 4
+  );
+
+  // Output format: "map " header + unused 4 bytes + width + height + 3 bytes per tile
+  const out = new Uint8Array(16 + tiles * 3);
+  out[0] = 0x6d; // 'm'
+  out[1] = 0x61; // 'a'
+  out[2] = 0x70; // 'p'
+  out[3] = 0x20; // ' '
+  const dvOut = new DataView(out.buffer);
+  dvOut.setInt32(8, width, true);
+  dvOut.setInt32(12, height, true);
+
+  for (let i = 0; i < tiles; i++) {
+    const val = gridIn.getUint32(i * 4, true);
+    const height16 = val & 0xffff;
+    const tile16 = (val >>> 16) & 0xffff;
+    out[16 + 3 * i] = tile16 & 0xff;
+    out[16 + 3 * i + 1] = 0; // rotation unknown -> 0
+    out[16 + 3 * i + 2] = height16 >>> 8; // keep top 8 bits
+  }
+
+  return out;
+}

--- a/js/game.js
+++ b/js/game.js
@@ -15,6 +15,7 @@ function normalizeTexPath(name){
 let showPanelIdsCheckbox;
 import { TILESETS, getTileCount, loadAllTiles, clearTileCache } from './tileset.js';
 import { parseMapGrid, getTilesetIndexFromTtp } from './maploader.js';
+import { convertGammaGameMapToClassic } from './convert.js';
 import { cameraState, resetCameraTarget, setupKeyboard } from './camera.js';
 import { parsePie, loadPieGeometry } from "./pie.js";
 import { buildStructureGroup } from "./structureGroup.js";
@@ -2202,7 +2203,9 @@ async function loadMapFile(file) {
   let autoTs = 0;
   if (fileExt === 'map') {
     const buf = await file.arrayBuffer();
-    const fileData = new Uint8Array(buf);
+    let fileData = new Uint8Array(buf);
+    const converted = convertGammaGameMapToClassic(fileData);
+    if (converted) fileData = converted;
     await setTileset(autoTs);
     const result = parseMapGrid(fileData);
     if (result) {
@@ -2231,6 +2234,8 @@ async function loadMapFile(file) {
     let mapFileName = allMapNames.find(f => f.toLowerCase().endsWith("game.map")) || allMapNames[0];
     if (mapFileName) {
       let fileData = await zip.files[mapFileName].async("uint8array");
+      const converted = convertGammaGameMapToClassic(fileData);
+      if (converted) fileData = converted;
       await setTileset(autoTs);
       const result = parseMapGrid(fileData);
       if (result) {


### PR DESCRIPTION
## Summary
- add convert.js to transform Gamma style game.map data into classic 3-byte-per-tile format
- apply conversion during map file loading so Gamma maps open correctly

## Testing
- `node -e "import fs from 'fs';import {convertGammaGameMapToClassic} from './wzmap/js/convert.js';import {parseMapGrid} from './wzmap/js/maploader.js';const data=fs.readFileSync('/tmp/gamma_game.map');const gamma=new Uint8Array(data);const conv=convertGammaGameMapToClassic(gamma);console.log('converted',conv?conv.length:0);const parsed=parseMapGrid(conv);console.log(parsed.mapW, parsed.mapH);"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b898958d908333a400c74447a949eb