### PR TITLE
Fix tile parsing in Gamma map converter

### DIFF
--- a/js/convert.js
+++ b/js/convert.js
@@ -46,11 +46,15 @@ export function convertGammaGameMapToClassic(gammaData) {
 
   for (let i = 0; i < tiles; i++) {
     const val = gridIn.getUint32(i * 4, true);
-    const height16 = val & 0xffff;
-    const tile16 = (val >>> 16) & 0xffff;
-    out[16 + 3 * i] = tile16 & 0xff;
-    out[16 + 3 * i + 1] = 0; // rotation unknown -> 0
-    out[16 + 3 * i + 2] = height16 & 0xff; // keep lowest 8 bits
+    // Gamma stores per-tile data as: height (byte0), tile index (byte1),
+    // rotation/flags (byte2), extra height bits (byte3).
+    // Classic format expects: tile index, rotation, height (8-bit).
+    const height = val & 0xff;
+    const tile = (val >>> 8) & 0xff;
+    const rotation = (val >>> 16) & 0xff;
+    out[16 + 3 * i] = tile;
+    out[16 + 3 * i + 1] = rotation;
+    out[16 + 3 * i + 2] = height;
   }
 
   return out;


### PR DESCRIPTION
## Summary
- Correct byte layout when converting Gamma `game.map` files to classic 3-byte tile format
- Preserve tile index, rotation, and height so tiles no longer appear as water in game

## Testing
- `npm test`
- `node --input-type=module <<'NODE'
import { convertGammaGameMapToClassic } from './js/convert.js';
import { execSync } from 'node:child_process';
const gamma = execSync('unzip -p maps/3p-Gamma.wz game.map');
const out = convertGammaGameMapToClassic(new Uint8Array(gamma));
console.log(out.length);
console.log(Array.from(out.slice(16, 16 + 9)));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b8a3f68d308333b90baf3d4c0bdca7