### PR TITLE
Handle binary ttypes files and strip rotation bits

### DIFF
--- a/js/convert.js
+++ b/js/convert.js
@@ -1,17 +1,40 @@
 // Convert Gamma-style game.map data to classic 3-byte-per-tile map format.
 // Based on gamma_to_classic.py
 
-export function parseTTypes(text) {
-  if (!text) return null;
-  const lines = text.split(/\r?\n/);
-  const mapping = [];
-  for (const line of lines) {
-    const parts = line.trim().split(/\s+/);
-    if (parts.length >= 2) {
-      const idx = parseInt(parts[0]);
-      if (!isNaN(idx)) {
-        mapping[idx] = idx; // currently 1:1 mapping
+export function parseTTypes(data) {
+  if (!data) return null;
+  // Support older plain-text .ttp files for backwards compatibility
+  if (typeof data === 'string') {
+    const lines = data.split(/\r?\n/);
+    const mapping = [];
+    for (const line of lines) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length >= 2) {
+        const idx = parseInt(parts[0]);
+        if (!isNaN(idx)) {
+          mapping[idx] = idx; // identity mapping
+        }
       }
+    }
+    return mapping;
+  }
+
+  // Binary .ttp file: verify header and build mapping stripping rotation bits
+  if (
+    data[0] !== 0x74 || // t
+    data[1] !== 0x74 || // t
+    data[2] !== 0x79 || // y
+    data[3] !== 0x70    // p
+  ) {
+    return null;
+  }
+  const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const entryCount = dv.getUint32(8, true);
+  const mapping = [];
+  for (let i = 0; i < entryCount; i++) {
+    for (let rot = 0; rot < 4; rot++) {
+      // Map all rotated versions of the tile ID to the base index
+      mapping[(i << 2) | rot] = i;
     }
   }
   return mapping;
@@ -64,8 +87,9 @@ export function convertGammaGameMapToClassic(gammaData, ttypesMap) {
     const val = gridIn.getUint32(i * 4, true);
     const height16 = val & 0xffff;
     const tile16 = (val >>> 16) & 0xffff;
+    const baseTile = tile16 >>> 2; // drop rotation bits
     const mappedTile =
-      ttypesMap && ttypesMap[tile16] !== undefined ? ttypesMap[tile16] : tile16;
+      ttypesMap && ttypesMap[tile16] !== undefined ? ttypesMap[tile16] : baseTile;
     out[16 + 3 * i] = mappedTile & 0xff;
     out[16 + 3 * i + 1] = 0; // rotation unknown -> 0
     out[16 + 3 * i + 2] = height16 & 0xff; // keep lowest 8 bits

--- a/js/game.js
+++ b/js/game.js
@@ -2231,8 +2231,8 @@ async function loadMapFile(file) {
     const ttypesName = names.find(n => n.toLowerCase().endsWith('ttypes.ttp'));
     let ttypesMap = null;
     if (ttypesName) {
-      const ttypesText = await zip.files[ttypesName].async('string');
-      ttypesMap = parseTTypes(ttypesText);
+      const ttypesData = await zip.files[ttypesName].async('uint8array');
+      ttypesMap = parseTTypes(ttypesData);
     }
     autoTs = await getTilesetIndexFromTtp(zip, TTP_TILESET_MAP);
     let allMapNames = Object.keys(zip.files)


### PR DESCRIPTION
## Summary
- parse `ttypes.ttp` as a binary structure and build tile mapping without rotation flags
- strip rotation bits when converting Gamma maps and map to base tile indices
- load `ttypes.ttp` from `.wz` archives as `Uint8Array`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d11f2dac8333860386872e1b898e