### PR TITLE
Fix tile index decoding for binary maps

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2444,7 +2444,8 @@ function drawMap3D() {
   const uniqueTiles = new Map();
   for (let y = 0; y < mapH; ++y) {
     for (let x = 0; x < mapW; ++x) {
-      const tileIdx = mapTiles[y][x] % tileCount;
+      const rawIdx = mapTiles[y][x] & 0x7f;
+      const tileIdx = rawIdx < tileCount ? rawIdx : 0;
       const hVal = mapHeights[y][x];
       const key = showHeight ? `${tileIdx}_${hVal}` : String(tileIdx);
       if (!uniqueTiles.has(key)) {

--- a/js/maploader.js
+++ b/js/maploader.js
@@ -2,12 +2,12 @@
 
 // --- Constants from WZ sources (used to unpack the 16-bit tile "texture" field)
 const ELEVATION_SCALE = 2;             // v39 stores height/2 in a byte
-const TILE_XFLIP   = 0x8000;
-const TILE_YFLIP   = 0x4000;
-const TILE_ROTMASK = 0x3000;
-const TILE_ROTSHIFT = 12;
-const TILE_TRIFLIP = 0x0800;
-const TILE_NUMMASK = 0x01ff;           // 9-bit tile index
+const TILE_INDEX_SHIFT = 5;            // low 5 bits store rotation/flip flags
+const TILE_INDEX_MASK  = 0x01ff;       // 9-bit tile index after shifting
+const TILE_ROTMASK     = 0x0003;       // rotation stored in lowest 2 bits
+const TILE_XFLIP       = 0x0008;
+const TILE_YFLIP       = 0x0010;
+const TILE_TRIFLIP     = 0x0004;
 
 // ------------------------
 // Binary .map grid parsing (v39=3 bytes/tile, v40+=4 bytes/tile)
@@ -51,9 +51,9 @@ export function parseBinaryMap(fileData) {
         ofs += 1;
       }
 
-      const tileIndex = tilenum & TILE_NUMMASK;                 // 0..511
-      const rotation  = (tilenum & TILE_ROTMASK) >> TILE_ROTSHIFT; // 0..3
-      // (xFlip/yFlip/triFlip available if you need them)
+      const tileIndex = (tilenum >> TILE_INDEX_SHIFT) & TILE_INDEX_MASK; // base tile
+      const rotation  = tilenum & TILE_ROTMASK;                            // 0..3
+      // (xFlip/yFlip/triFlip available if needed)
       // const xFlip = !!(tilenum & TILE_XFLIP);
       // const yFlip = !!(tilenum & TILE_YFLIP);
       // const triFlip = !!(tilenum & TILE_TRIFLIP);

--- a/js/tileset.js
+++ b/js/tileset.js
@@ -82,7 +82,7 @@ export async function loadAllTiles(tilesetIndex, count = getTileCount(tilesetInd
     for (let i = 0; i < count; i++) if (imgs[i]) out.push(imgs[i]);
 
     try {
-      console.log(`[tileset] ${folder} -> loaded ${out.length} tiles (declared count 1046 ${count})`);
+      console.log(`[tileset] ${folder} -> loaded ${out.length} tiles (declared count ${count})`);
     } catch {}
     return out;
   })();


### PR DESCRIPTION
## Summary
- Decode binary map tile indices by shifting out low-bit flags and using low bits for rotation
- Prevent tile index wrapping and clamp to available textures when rendering
- Clean up tileset loader logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b90123bc4c83339371e9ff971d0e9a