### PR TITLE
Fix undefined showTileTypesCheckbox causing ReferenceError

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -82,6 +82,7 @@ if (showHeightBtn) {
 
 // Tile types on 3D map toggle
 const showTileTypesOnMapCheckbox = document.getElementById('showTileTypesOnMap');
+const showTileTypesCheckbox = document.getElementById('displayTileTypes');
 const showTileInfoCheckbox = document.getElementById('showTileInfo');
 const tileInfoButtonsDiv = document.getElementById('tileInfoButtons');
 const tileOptionsBox = document.getElementById('tileOptions');


### PR DESCRIPTION
## Summary
- define showTileTypesCheckbox to reference displayTileTypes checkbox

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9695566908333b8f7165b39ad2723