### PR TITLE
Use basic material to prevent color shift on flipped tiles

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2502,8 +2502,8 @@ try {
       tex = null;
     }
     const material = tex ?
-      new THREE.MeshLambertMaterial({ map: tex, side: THREE.DoubleSide }) :
-      new THREE.MeshLambertMaterial({ color: 0x393, side: THREE.DoubleSide });
+      new THREE.MeshBasicMaterial({ map: tex, side: THREE.DoubleSide }) :
+      new THREE.MeshBasicMaterial({ color: 0x393, side: THREE.DoubleSide });
     const instancedMesh = new THREE.InstancedMesh(tileGeometry, material, positions.length);
     positions.forEach((pos, i) => {
       const h = Math.max(pos.h * HEIGHT_SCALE, 0.01);


### PR DESCRIPTION
## Summary
- Render map tiles with `MeshBasicMaterial` so flipping them doesn't alter their colors

## Testing
- `node --check js/game.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9771a8c0483338886f2ec8c3f4b6d