### PR TITLE
Fix remaining flipped tiles by adjusting transform order

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2514,7 +2514,8 @@ try {
       const rotationMatrix = new THREE.Matrix4().makeRotationY(rotation);
       const scaleMatrix = new THREE.Matrix4().makeScale(flipX, h, flipZ);
       const translationMatrix = new THREE.Matrix4().makeTranslation(pos.x + 0.5, h / 2, pos.y + 0.5);
-      matrix.multiply(translationMatrix).multiply(rotationMatrix).multiply(scaleMatrix);
+      // Apply rotation before flip so flip flags reflect the final tile orientation
+      matrix.multiply(translationMatrix).multiply(scaleMatrix).multiply(rotationMatrix);
       instancedMesh.setMatrixAt(i, matrix);
     });
     instancedMesh.instanceMatrix.needsUpdate = true;


### PR DESCRIPTION
## Summary
- Apply flip scaling after tile rotation so flip flags use final tile orientation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b97ccf423c8333b4bc5ef1c3f2b022