### PR TITLE
Handle v10 classic maps and v39+ new maps

### DIFF
--- a/js/convert.js
+++ b/js/convert.js
@@ -74,7 +74,7 @@ export function convertGammaGameMapToClassic(gammaData, ttypesMap) {
   out[3] = 0x20; // ' '
 
   const dvOut = new DataView(out.buffer);
-  dvOut.setUint32(4, 39, true);     // classic binary map version (3 bytes/tile)
+  dvOut.setUint32(4, 10, true);     // classic v10 binary map version (3 bytes/tile)
   dvOut.setInt32(8, width, true);
   dvOut.setInt32(12, height, true);
 

--- a/js/game.js
+++ b/js/game.js
@@ -2233,7 +2233,7 @@ async function loadMapFile(file) {
     mapXFlip = mapData.mapXFlip || mapXFlip;
     mapYFlip = mapData.mapYFlip || mapYFlip;
     mapTriFlip = mapData.mapTriFlip || mapTriFlip;
-    updateHeightUI(mapData.mapVersion >= 40 ? 1023 : 255);
+    updateHeightUI(mapData.mapVersion >= 39 ? 1023 : 255);
     resetCameraTarget(mapW, mapH, threeContainer);
     infoDiv.innerHTML = '<b>Loaded map grid:</b> <span style="color:yellow">' + file.name + '</span><br>Tileset: ' + TILESETS[tilesetIndex].name + '<br>Size: ' + mapW + 'x' + mapH;
     drawMap3D();
@@ -2270,7 +2270,7 @@ async function loadMapFile(file) {
         mapXFlip = result.mapXFlip || mapXFlip;
         mapYFlip = result.mapYFlip || mapYFlip;
         mapTriFlip = result.mapTriFlip || mapTriFlip;
-        updateHeightUI(result.mapVersion >= 40 ? 1023 : 255);
+        updateHeightUI(result.mapVersion >= 39 ? 1023 : 255);
         const ttpName = Object.keys(zip.files).find(fn => fn.toLowerCase().endsWith('.ttp') && !zip.files[fn].dir);
         if (ttpName) {
           const ttpData = await zip.files[ttpName].async('uint8array');


### PR DESCRIPTION
## Summary
- treat version 10 maps as the legacy 3-byte tile format
- recognize versions 39+ as 4-byte maps with 16-bit heights
- convert gamma maps to v10 and update height UI thresholds

## Testing
- `cd js && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9944fdad883338e7b5f8e81436447